### PR TITLE
Include Compose compiler in kotlin renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,7 @@
       "groupName": "kotlin",
       "description": "Kotlin and Compose dependencies that must be updated together to maintain compatibility.",
       "matchPackagePatterns": [
+        "androidx.compose.compiler:compiler",
         "androidx.compose:compose-bom",
         "org.jetbrains.kotlin.*",
         "com.google.devtools.ksp"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,8 @@ androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycl
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "androidxCamera" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidxComposeBom" }
+# Included so that Renovate tracks updates since Compose Compiler is not referenced directly in `dependency {}` blocks.
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "kotlinCompilerExtensionVersion" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Include Compose compiler package in the Kotlin + Compose renovate group so they are updated together.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
