### PR TITLE
Refactor primary data model

### DIFF
--- a/app/schemas/com.x8bit.bitwarden.authenticator.data.authenticator.datasource.disk.database.AuthenticatorDatabase/1.json
+++ b/app/schemas/com.x8bit.bitwarden.authenticator.data.authenticator.datasource.disk.database.AuthenticatorDatabase/1.json
@@ -2,15 +2,27 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "3cc9605b629947b2b4148a40ff0d955d",
+    "identityHash": "8724b95439edde85bd15e0bd2e02195e",
     "entities": [
       {
         "tableName": "items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `algorithm` TEXT NOT NULL, `period` INTEGER NOT NULL, `digits` INTEGER NOT NULL, `key` TEXT NOT NULL, `issuer` TEXT, `userId` TEXT, `username` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `key` TEXT NOT NULL, `accountName` TEXT NOT NULL, `type` TEXT NOT NULL, `algorithm` TEXT NOT NULL, `period` INTEGER NOT NULL, `digits` INTEGER NOT NULL, `issuer` TEXT, `userId` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
             "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -39,12 +51,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "key",
-            "columnName": "key",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
             "fieldPath": "issuer",
             "columnName": "issuer",
             "affinity": "TEXT",
@@ -53,12 +59,6 @@
           {
             "fieldPath": "userId",
             "columnName": "userId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "username",
-            "columnName": "username",
             "affinity": "TEXT",
             "notNull": false
           }
@@ -76,7 +76,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3cc9605b629947b2b4148a40ff0d955d')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8724b95439edde85bd15e0bd2e02195e')"
     ]
   }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
@@ -13,6 +13,12 @@ data class AuthenticatorItemEntity(
     @ColumnInfo(name = "id")
     val id: String,
 
+    @ColumnInfo(name = "key")
+    val key: String,
+
+    @ColumnInfo(name = "accountName")
+    val accountName: String,
+
     @ColumnInfo(name = "type")
     val type: AuthenticatorItemType = AuthenticatorItemType.TOTP,
 
@@ -25,15 +31,9 @@ data class AuthenticatorItemEntity(
     @ColumnInfo(name = "digits")
     val digits: Int = 6,
 
-    @ColumnInfo(name = "key")
-    val key: String,
-
     @ColumnInfo(name = "issuer")
-    val issuer: String?,
+    val issuer: String? = null,
 
     @ColumnInfo(name = "userId")
-    val userId: String?,
-
-    @ColumnInfo(name = "username")
-    val username: String?,
+    val userId: String? = null,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
@@ -96,7 +96,7 @@ class TotpCodeManagerImpl @Inject constructor(
                                         time % response.period.toInt(),
                                     issueTime = clock.millis(),
                                     id = cipherId,
-                                    username = itemEntity.username,
+                                    username = itemEntity.accountName,
                                     issuer = itemEntity.issuer,
                                 )
                             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
@@ -64,7 +64,7 @@ interface AuthenticatorRepository {
     /**
      * Attempt to create a cipher.
      */
-    suspend fun createItem(code: String, issuer: String): CreateItemResult
+    suspend fun createItem(item: AuthenticatorItemEntity): CreateItemResult
 
     /**
      * Attempt to delete a cipher.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/repository/model/UpdateItemRequest.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/authenticator/repository/model/UpdateItemRequest.kt
@@ -6,34 +6,32 @@ import com.x8bit.bitwarden.authenticator.data.authenticator.datasource.disk.enti
 /**
  * Models a request to modify an existing authenticator item.
  *
+ * @property key Key used to generate verification codes for the authenticator item.
+ * @property accountName Required account or username associated with the item.
  * @property type Type of authenticator item.
  * @property algorithm Hashing algorithm applied to the authenticator item verification code.
- * @property period Time, in seconds, the authenticator item verification code is valid. Default is
- * 30 seconds.
+ * @property period Time, in seconds, the authenticator item verification code is valid.
  * @property digits Number of digits contained in the verification code for this authenticator item.
- * Default is 6 digits.
- * @property key Key used to generate verification codes for the authenticator item.
  * @property issuer Entity that provided the authenticator item.
- * @property username Optional username associated with .
  */
 data class UpdateItemRequest(
-    val type: AuthenticatorItemType,
-    val algorithm: AuthenticatorItemAlgorithm = AuthenticatorItemAlgorithm.SHA1,
-    val period: Int = 30,
-    val digits: Int = 6,
     val key: String,
+    val accountName: String,
+    val type: AuthenticatorItemType,
+    val algorithm: AuthenticatorItemAlgorithm,
+    val period: Int,
+    val digits: Int,
     val issuer: String?,
-    val username: String?,
 ) {
     /**
-     * The composite label of the authenticator item.
+     * The composite label of the authenticator item. Derived from combining [issuer] and [accountName]
      *  ```
-     *  label = issuer (“:” / “%3A”) *”%20” username
+     *  label = accountName /issuer (“:” / “%3A”) *”%20” accountName
      *  ```
      */
     val label = if (issuer != null) {
-        issuer + username?.let { ":$it" }.orEmpty()
+        "$issuer:$accountName"
     } else {
-        username.orEmpty()
+        accountName
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/platform/repository/util/DataStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/data/platform/repository/util/DataStateExtensions.kt
@@ -1,6 +1,8 @@
 package com.x8bit.bitwarden.authenticator.data.platform.repository.util
 
 import com.x8bit.bitwarden.authenticator.data.platform.repository.model.DataState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.transformWhile
 
 /**
  * Maps the data inside a [DataState] with the given [transform].
@@ -13,6 +15,14 @@ inline fun <T : Any?, R : Any?> DataState<T>.map(
     is DataState.Pending -> DataState.Pending(transform(data))
     is DataState.Error -> DataState.Error(error, data?.let(transform))
     is DataState.NoNetwork -> DataState.NoNetwork(data?.let(transform))
+}
+
+/**
+ * Emits all values of a [DataState] [Flow] until it emits a [DataState.Loaded].
+ */
+fun <T : Any?> Flow<DataState<T>>.takeUntilLoaded(): Flow<DataState<T>> = transformWhile {
+    emit(it)
+    it !is DataState.Loaded
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/authenticator/feature/item/ItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/authenticator/feature/item/ItemViewModel.kt
@@ -58,7 +58,7 @@ class ItemViewModel @Inject constructor(
 
                     TotpCodeItemData(
                         type = item.type,
-                        username = item.username?.asText(),
+                        username = item.accountName.asText(),
                         issuer = item.issuer.orEmpty().asText(),
                         periodSeconds = authCode.periodSeconds,
                         timeLeftSeconds = authCode.timeLeftSeconds,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.authenticator.ui.authenticator.feature.manualcodeent
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.x8bit.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.x8bit.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.x8bit.bitwarden.authenticator.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.authenticator.ui.platform.base.util.Text
@@ -10,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.util.UUID
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"
@@ -55,7 +57,14 @@ class ManualCodeEntryViewModel @Inject constructor(
 
     private fun handleCodeSubmit() {
         viewModelScope.launch {
-            authenticatorRepository.createItem(state.code, state.issuer)
+            authenticatorRepository.createItem(
+                AuthenticatorItemEntity(
+                    id = UUID.randomUUID().toString(),
+                    key = state.code,
+                    accountName = "",
+                    issuer = state.issuer,
+                )
+            )
         }
         sendEvent(ManualCodeEntryEvent.NavigateBack)
     }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Refactor primary data model to better reflect industry terminology.


- **AuthenticatorItemEntity.kt:** Rename property `username` to `accountName`.
- **TotpCodeManagerImpl.kt:** Replace entity `username` references with `accountName`.
- **UpdateItemRequest.kt:** 
  - Rename property `username` to `accountName` to reflect similar change in entity object.
  - Remove default property values
- **AuthenticatorRepository.kt:** Updated `createItem` signature to accept an `AuthenticatorItemEntity` parameter.
- **AuthenticatorRepositoryImpl.kt:** Updated `createItem` function to accommodate interface changes. 
- **DataStateExtensions.kt:** Add ext function to observe a flow while it is loading.
- **ItemViewModel.kt:** Update references of entity property `username` to `accountName`.
- **ManualCodeEntryViewModel.kt:** Update references to `createItem` so that an `AuthenticatorItemEntity` instance is provided.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
