### PR TITLE
Update settings tutorial label

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -255,7 +255,7 @@ private fun HelpSettings(
         label = stringResource(id = R.string.help)
     )
     BitwardenTextRow(
-        text = stringResource(id = R.string.tutorial),
+        text = stringResource(id = R.string.launch_tutorial),
         onClick = onTutorialClick,
         modifier = modifier,
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="get_started">Get started</string>
     <string name="unique_codes">Uniqe codes</string>
     <string name="help">Help</string>
-    <string name="tutorial">Tutorial</string>
+    <string name="launch_tutorial">Launch tutorial</string>
     <string name="value_has_been_copied">%1$s copied</string>
     <string name="delete_item">Delete item</string>
     <string name="item_deleted">Item deleted</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Change the label of the settings option used to start the tutorial so that it reads "Launch tutorial."

## 📸 Screenshots

<img width="274" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/76b5df6a-c1a8-4f45-9047-75785212e417">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
