### PR TITLE
Remove Sync with Bitwarden button

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingGraphNavigation.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingGraphNavigation.kt
@@ -35,11 +35,7 @@ fun NavGraphBuilder.itemListingGraph(
             onNavigateToQrCodeScanner = navigateToQrCodeScanner,
             onNavigateToManualKeyEntry = navigateToManualKeyEntry,
             onNavigateToEditItemScreen = navigateToEditItem,
-            onNavigateToSyncWithBitwardenScreen = {
-                /*navController.navigateToSyncWithBitwardenScreen()*/
-            },
-            onNavigateToImportScreen = { /*navController.navigateToImportScreen()*/ }
-        )
+        ) { /*navController.navigateToImportScreen()*/ }
         editItemDestination(
             onNavigateBack = { navController.popBackStack() },
         )

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingNavigation.kt
@@ -14,7 +14,6 @@ fun NavGraphBuilder.itemListingDestination(
     onNavigateToQrCodeScanner: () -> Unit = { },
     onNavigateToManualKeyEntry: () -> Unit = { },
     onNavigateToEditItemScreen: (id: String) -> Unit = { },
-    onNavigateToSyncWithBitwardenScreen: () -> Unit = { },
     onNavigateToImportScreen: () -> Unit = { },
 ) {
     composableWithPushTransitions(
@@ -26,7 +25,6 @@ fun NavGraphBuilder.itemListingDestination(
             onNavigateToQrCodeScanner = onNavigateToQrCodeScanner,
             onNavigateToManualKeyEntry = onNavigateToManualKeyEntry,
             onNavigateToEditItemScreen = onNavigateToEditItemScreen,
-            onNavigateToSyncWithBitwardenScreen = onNavigateToSyncWithBitwardenScreen,
             onNavigateToImportScreen = onNavigateToImportScreen
         )
     }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -81,7 +81,6 @@ fun ItemListingScreen(
     onNavigateToQrCodeScanner: () -> Unit,
     onNavigateToManualKeyEntry: () -> Unit,
     onNavigateToEditItemScreen: (id: String) -> Unit,
-    onNavigateToSyncWithBitwardenScreen: () -> Unit,
     onNavigateToImportScreen: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -278,7 +277,6 @@ fun ItemListingScreen(
                 -> {
                     EmptyItemListingContent(
                         onAddCodeClick = onNavigateToQrCodeScanner,
-                        onSyncWithBitwardenClick = onNavigateToSyncWithBitwardenScreen,
                         onImportItemsClick = onNavigateToImportScreen,
                     )
                 }
@@ -337,7 +335,6 @@ private fun ItemListingDialogs(
 fun EmptyItemListingContent(
     modifier: Modifier = Modifier,
     onAddCodeClick: () -> Unit = {},
-    onSyncWithBitwardenClick: () -> Unit = {},
     onImportItemsClick: () -> Unit = {},
 ) {
     Column(
@@ -373,12 +370,6 @@ fun EmptyItemListingContent(
             modifier = Modifier.fillMaxWidth(),
             label = stringResource(R.string.add_code),
             onClick = onAddCodeClick,
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-        BitwardenTextButton(
-            label = stringResource(id = R.string.sync_items_with_bitwarden),
-            onClick = onSyncWithBitwardenClick,
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,11 +32,8 @@
     <string name="you_dont_have_items_to_display">You don\'t have any items to display.</string>
     <string name="empty_item_list_instruction">Add a new code, sync an existing account, or import codes to secure your accounts.</string>
     <string name="add_code">Add code</string>
-    <string name="sync_items_with_bitwarden">Sync items from Bitwarden</string>
     <string name="import_items">Import items</string>
     <string name="account_name">Account Name</string>
-    <string name="totp_code">TOTP Code</string>
-    <string name="type">Type</string>
     <string name="authenticator_key_read_error">Cannot read authenticator key.</string>
     <string name="authenticator_key_added">Authenticator key added.</string>
     <string name="item_added">Item added</string>
@@ -63,7 +60,6 @@
     <string name="search_codes">Search codes</string>
     <string name="options">Options</string>
     <string name="try_again">Try again</string>
-    <string name="not_yet_implemented">Not yet implemented</string>
     <string name="appearance">Appearance</string>
     <string name="default_system">Default (System)</string>
     <string name="theme">Theme</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Remove the "Sync with Bitwarden" button from the empty listing screen.

## 📸 Screenshots

| Screen | Dark Theme | Light Theme |
|--------|--------|--------|
| Item Listing - Empty | <img width="272" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/53fbab69-da0d-40b2-b913-f812fb267c28"> | <img width="272" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/84ed3a11-03e2-4206-8340-42a395d77eaa"> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
