### PR TITLE
Remove Import button from empty item listing screen

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingGraphNavigation.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingGraphNavigation.kt
@@ -35,7 +35,7 @@ fun NavGraphBuilder.itemListingGraph(
             onNavigateToQrCodeScanner = navigateToQrCodeScanner,
             onNavigateToManualKeyEntry = navigateToManualKeyEntry,
             onNavigateToEditItemScreen = navigateToEditItem,
-        ) { /*navController.navigateToImportScreen()*/ }
+        )
         editItemDestination(
             onNavigateBack = { navController.popBackStack() },
         )

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingNavigation.kt
@@ -14,7 +14,6 @@ fun NavGraphBuilder.itemListingDestination(
     onNavigateToQrCodeScanner: () -> Unit = { },
     onNavigateToManualKeyEntry: () -> Unit = { },
     onNavigateToEditItemScreen: (id: String) -> Unit = { },
-    onNavigateToImportScreen: () -> Unit = { },
 ) {
     composableWithPushTransitions(
         route = ITEM_LIST_ROUTE,
@@ -25,7 +24,6 @@ fun NavGraphBuilder.itemListingDestination(
             onNavigateToQrCodeScanner = onNavigateToQrCodeScanner,
             onNavigateToManualKeyEntry = onNavigateToManualKeyEntry,
             onNavigateToEditItemScreen = onNavigateToEditItemScreen,
-            onNavigateToImportScreen = onNavigateToImportScreen
         )
     }
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -81,7 +81,6 @@ fun ItemListingScreen(
     onNavigateToQrCodeScanner: () -> Unit,
     onNavigateToManualKeyEntry: () -> Unit,
     onNavigateToEditItemScreen: (id: String) -> Unit,
-    onNavigateToImportScreen: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -277,7 +276,6 @@ fun ItemListingScreen(
                 -> {
                     EmptyItemListingContent(
                         onAddCodeClick = onNavigateToQrCodeScanner,
-                        onImportItemsClick = onNavigateToImportScreen,
                     )
                 }
             }
@@ -335,7 +333,6 @@ private fun ItemListingDialogs(
 fun EmptyItemListingContent(
     modifier: Modifier = Modifier,
     onAddCodeClick: () -> Unit = {},
-    onImportItemsClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -370,12 +367,6 @@ fun EmptyItemListingContent(
             modifier = Modifier.fillMaxWidth(),
             label = stringResource(R.string.add_code),
             onClick = onAddCodeClick,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-        BitwardenTextButton(
-            label = stringResource(id = R.string.import_items),
-            onClick = onImportItemsClick,
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,6 @@
     <string name="you_dont_have_items_to_display">You don\'t have any items to display.</string>
     <string name="empty_item_list_instruction">Add a new code, sync an existing account, or import codes to secure your accounts.</string>
     <string name="add_code">Add code</string>
-    <string name="import_items">Import items</string>
     <string name="account_name">Account Name</string>
     <string name="authenticator_key_read_error">Cannot read authenticator key.</string>
     <string name="authenticator_key_added">Authenticator key added.</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Remove import button from empty listing screen.

## 📸 Screenshots

| Screen | Dark Theme | Light Theme |
|--------|--------|--------|
| Item Listing - Empty | <img width="272" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/bca5e1f8-4353-4434-b4ac-b7fd7a96781c"> | <img width="272" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/a9e4d4de-c046-40de-8d8e-5a3cc1f4f4f7"> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
