### PR TITLE
Increase spacing in tutorial slide content

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -177,11 +178,13 @@ private fun VerificationCodesContent() {
             id = R.string.secure_your_accounts_with_bitwarden_authenticator,
         ),
     )
+    Spacer(Modifier.height(24.dp))
     Text(
         style = MaterialTheme.typography.headlineSmall,
         textAlign = TextAlign.Center,
         text = stringResource(R.string.secure_your_accounts_with_bitwarden_authenticator),
     )
+    Spacer(Modifier.height(8.dp))
     Text(
         style = MaterialTheme.typography.bodyLarge,
         textAlign = TextAlign.Center,
@@ -195,6 +198,7 @@ private fun TutorialQrScannerScreen() {
         painter = painterResource(id = R.drawable.ic_tutorial_qr_scanner),
         contentDescription = stringResource(id = R.string.scan_qr_code),
     )
+    Spacer(Modifier.height(24.dp))
     Text(
         style = MaterialTheme.typography.headlineSmall,
         textAlign = TextAlign.Center,
@@ -202,6 +206,7 @@ private fun TutorialQrScannerScreen() {
             R.string.use_your_device_camera_to_scan_codes
         ),
     )
+    Spacer(Modifier.height(8.dp))
     Text(
         style = MaterialTheme.typography.bodyLarge,
         textAlign = TextAlign.Center,
@@ -217,11 +222,13 @@ private fun UniqueCodesContent() {
         painter = painterResource(id = R.drawable.ic_tutorial_2fa),
         contentDescription = stringResource(id = R.string.unique_codes)
     )
+    Spacer(Modifier.height(24.dp))
     Text(
         style = MaterialTheme.typography.headlineSmall,
         textAlign = TextAlign.Center,
         text = stringResource(R.string.sign_in_using_unique_codes),
     )
+    Spacer(Modifier.height(8.dp))
     Text(
         style = MaterialTheme.typography.bodyLarge,
         textAlign = TextAlign.Center,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Increase spacing between image and text on the tutorial slides.

## 📸 Screenshots

Coming soon

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
