### PR TITLE
Allow fallback to device credential when biometrics fails

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -78,8 +78,9 @@ class BiometricsManagerImpl(
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(activity.getString(R.string.bitwarden_authenticator))
             .setDescription(activity.getString(R.string.biometrics_direction))
-            .setNegativeButtonText(activity.getString(R.string.cancel))
-            .setAllowedAuthenticators(Authenticators.BIOMETRIC_STRONG)
+            .setAllowedAuthenticators(
+                Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
+            )
             .build()
 
         biometricPrompt.authenticate(promptInfo)


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Allow users to unlock with their device credential in cases when biometrics fails or is unavailable.

## 📸 Screenshots

<img width="374" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/b5279cc5-5785-47bb-b26e-2474cc4dc2d9">

<img width="368" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/b4a0e493-7a47-4f71-b36f-33653e0482e5">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
