### PR TITLE
Convert digits input to stepper

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/model/EditItemData.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/model/EditItemData.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.AuthenticatorRefreshPeriodOption
-import com.bitwarden.authenticator.ui.authenticator.feature.edititem.VerificationCodeDigitsOption
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -25,5 +24,5 @@ data class EditItemData(
     val username: String?,
     val issuer: String,
     val algorithm: AuthenticatorItemAlgorithm,
-    val digits: VerificationCodeDigitsOption,
+    val digits: Int,
 ) : Parcelable

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/base/util/StringExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/base/util/StringExtensions.kt
@@ -9,6 +9,23 @@ import java.text.Normalizer
 import kotlin.math.floor
 
 /**
+ * This character takes up no space but can be used to ensure a string is not empty. It can also
+ * be used to insert "safe" line-break positions in a string.
+ *
+ * Note: Is a string only contains this charactor, it is _not_ considered blank.
+ */
+const val ZERO_WIDTH_CHARACTER: String = "\u200B"
+/**
+ * Returns the original [String] only if:
+ *
+ * - it is non-null
+ * - it is not blank (where blank refers to empty strings of those containing only white space)
+ *
+ * Otherwise `null` is returned.
+ */
+fun String?.orNullIfBlank(): String? = this?.takeUnless { it.isBlank() }
+
+/**
  * Returns a new [String] that includes line breaks after [widthPx] worth of text. This is useful
  * for long values that need to smoothly flow onto the next line without the OS inserting line
  * breaks earlier at special characters.

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/stepper/BitwardenStepper.kt
@@ -1,0 +1,110 @@
+package com.bitwarden.authenticator.ui.platform.components.stepper
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.base.util.ZERO_WIDTH_CHARACTER
+import com.bitwarden.authenticator.ui.platform.base.util.orNullIfBlank
+import com.bitwarden.authenticator.ui.platform.components.field.BitwardenTextFieldWithActions
+import com.bitwarden.authenticator.ui.platform.components.icon.BitwardenIconButtonWithResource
+import com.bitwarden.authenticator.ui.platform.components.model.IconResource
+import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
+
+/**
+ * Displays a stepper that allows the user to increment and decrement an int value.
+ *
+ * @param label Label for the stepper.
+ * @param value Value to display. Null will display nothing. Will be clamped to [range] before
+ * display.
+ * @param onValueChange callback invoked when the user increments or decrements the count. Note
+ * that this will not be called if the attempts to move value outside of [range].
+ * @param modifier Modifier.
+ * @param range Range of valid values.
+ * @param isIncrementEnabled whether or not the increment button should be enabled.
+ * @param isDecrementEnabled whether or not the decrement button should be enabled.
+ * @param textFieldReadOnly whether or not the text field should be read only. The stepper
+ * increment and decrement buttons function regardless of this value.
+ */
+@Suppress("LongMethod")
+@Composable
+fun BitwardenStepper(
+    label: String,
+    value: Int?,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    range: ClosedRange<Int> = 1..Int.MAX_VALUE,
+    isIncrementEnabled: Boolean = true,
+    isDecrementEnabled: Boolean = true,
+    textFieldReadOnly: Boolean = true,
+    stepperActionsTestTag: String? = null,
+    increaseButtonTestTag: String? = null,
+    decreaseButtonTestTag: String? = null,
+) {
+    val clampedValue = value?.coerceIn(range)
+    if (clampedValue != value && clampedValue != null) {
+        onValueChange(clampedValue)
+    }
+    BitwardenTextFieldWithActions(
+        label = label,
+        // We use the zero width character instead of an empty string to make sure label is shown
+        // small and above the input
+        value = clampedValue
+            ?.toString()
+            ?: ZERO_WIDTH_CHARACTER,
+        actionsTestTag = stepperActionsTestTag,
+        actions = {
+            BitwardenIconButtonWithResource(
+                iconRes = IconResource(
+                    iconPainter = rememberVectorPainter(id = R.drawable.ic_minus),
+                    contentDescription = "\u2212",
+                ),
+                onClick = {
+                    val decrementedValue = ((value ?: 0) - 1).coerceIn(range)
+                    if (decrementedValue != value) {
+                        onValueChange(decrementedValue)
+                    }
+                },
+                isEnabled = isDecrementEnabled,
+                modifier = Modifier.semantics {
+                    if (decreaseButtonTestTag != null) {
+                        testTag = decreaseButtonTestTag
+                    }
+                },
+            )
+            BitwardenIconButtonWithResource(
+                iconRes = IconResource(
+                    iconPainter = rememberVectorPainter(id = R.drawable.ic_plus),
+                    contentDescription = "+",
+                ),
+                onClick = {
+                    val incrementedValue = ((value ?: 0) + 1).coerceIn(range)
+                    if (incrementedValue != value) {
+                        onValueChange(incrementedValue)
+                    }
+                },
+                isEnabled = isIncrementEnabled,
+                modifier = Modifier.semantics {
+                    if (increaseButtonTestTag != null) {
+                        testTag = increaseButtonTestTag
+                    }
+                },
+            )
+        },
+        readOnly = textFieldReadOnly,
+        keyboardType = KeyboardType.Number,
+        onValueChange = { newValue ->
+            onValueChange(
+                newValue
+                    // Make sure the placeholder is gone, since it will mess up the int conversion
+                    .replace(ZERO_WIDTH_CHARACTER, "")
+                    .orNullIfBlank()
+                    ?.let { it.toIntOrNull()?.coerceIn(range) ?: value }
+                    ?: range.start,
+            )
+        },
+        modifier = modifier,
+    )
+}

--- a/app/src/main/res/drawable/ic_minus.xml
+++ b/app/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M4.375,10C4.375,9.655 4.655,9.375 5,9.375H15C15.345,9.375 15.625,9.655 15.625,10C15.625,10.345 15.345,10.625 15,10.625H5C4.655,10.625 4.375,10.345 4.375,10Z"
+      android:fillColor="#151B2C"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Convert number of digits input to a stepper.

## 📸 Screenshots

| Screen | Dark | Light |
|--------|--------|--------|
| Edit Item | <img width="271" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/127436e4-6804-434a-8704-732309bba488"> | <img width="270" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/c3f0a455-6eb4-460e-b946-8289d199b5c2"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
