### PR TITLE
Update label for OTP type input field

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -352,7 +352,7 @@ private fun AdvancedOptions(
                         modifier = Modifier
                             .fillMaxSize()
                             .semantics { testTag = "ItemTypePicker" },
-                        label = stringResource(id = R.string.otp_authentication),
+                        label = stringResource(id = R.string.otp_type),
                         options = typeOptionsWithStrings.values.toImmutableList(),
                         selectedOption = viewState.itemData.type.name,
                         onOptionSelected = { selectedOption ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="saving">Saving</string>
     <string name="item_saved">Item saved</string>
     <string name="information">Information</string>
-    <string name="otp_authentication">OTP Authentication</string>
+    <string name="otp_type">OTP type</string>
     <string name="verification_codes">Verification codes</string>
     <string name="there_are_no_items_that_match_the_search">There are no items that match the search</string>
     <string name="back">Back</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Update the label for the OTP type field from "OTP Authentication" to "OTP type.

## 📸 Screenshots

| Header | Header | Header |
|--------|--------|--------|
| Edit Item | <img width="270" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/f85dfe28-db96-45e5-9d47-9970cf269f02"> | <img width="272" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/2d417961-735c-4ed5-be5e-d388047e5114"> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
