### PR TITLE
Allow users to select favorites

### DIFF
--- a/app/schemas/com.bitwarden.authenticator.data.authenticator.datasource.disk.database.AuthenticatorDatabase/2.json
+++ b/app/schemas/com.bitwarden.authenticator.data.authenticator.datasource.disk.database.AuthenticatorDatabase/2.json
@@ -1,0 +1,89 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "a4f979e34bbd67f2ddd263acdad12a38",
+    "entities": [
+      {
+        "tableName": "items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `key` TEXT NOT NULL, `type` TEXT NOT NULL, `algorithm` TEXT NOT NULL, `period` INTEGER NOT NULL, `digits` INTEGER NOT NULL, `issuer` TEXT NOT NULL, `userId` TEXT, `accountName` TEXT, `favorite` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "algorithm",
+            "columnName": "algorithm",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "digits",
+            "columnName": "digits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "issuer",
+            "columnName": "issuer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a4f979e34bbd67f2ddd263acdad12a38')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/database/AuthenticatorDatabase.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/database/AuthenticatorDatabase.kt
@@ -1,5 +1,6 @@
 package com.bitwarden.authenticator.data.authenticator.datasource.disk.database
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
@@ -15,7 +16,10 @@ import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.Aut
     entities = [
         AuthenticatorItemEntity::class
     ],
-    version = 1,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2),
+    ],
+    version = 2,
     exportSchema = true,
 )
 @TypeConverters(

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
@@ -38,6 +38,9 @@ data class AuthenticatorItemEntity(
 
     @ColumnInfo(name = "accountName")
     val accountName: String? = null,
+
+    @ColumnInfo(name = "favorite", defaultValue = "0")
+    val favorite: Boolean = false,
 ) {
     fun toOtpAuthUriString(): String {
         return when (type) {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemEntity.kt
@@ -40,7 +40,7 @@ data class AuthenticatorItemEntity(
     val accountName: String? = null,
 
     @ColumnInfo(name = "favorite", defaultValue = "0")
-    val favorite: Boolean = false,
+    val favorite: Boolean,
 ) {
     fun toOtpAuthUriString(): String {
         return when (type) {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
@@ -1,11 +1,11 @@
 package com.bitwarden.authenticator.data.authenticator.manager
 
-import com.bitwarden.core.DateTime
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.sdk.AuthenticatorSdkSource
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.platform.manager.DispatcherManager
 import com.bitwarden.authenticator.data.platform.repository.model.DataState
+import com.bitwarden.core.DateTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -98,6 +98,7 @@ class TotpCodeManagerImpl @Inject constructor(
                                     id = cipherId,
                                     username = itemEntity.accountName,
                                     issuer = itemEntity.issuer,
+                                    favorite = itemEntity.favorite,
                                 )
                             }
                             .onFailure {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/model/VerificationCodeItem.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/model/VerificationCodeItem.kt
@@ -20,6 +20,7 @@ data class VerificationCodeItem(
     val id: String,
     val username: String?,
     val issuer: String?,
+    val favorite: Boolean,
 ) {
     /**
      * The composite label of the authenticator item. Used for constructing an OTPAuth URI.

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
@@ -226,6 +226,7 @@ class AuthenticatorRepositoryImpl @Inject constructor(
                     digits = updateItemRequest.digits,
                     issuer = updateItemRequest.issuer,
                     userId = null,
+                    favorite = updateItemRequest.favorite
                 ),
             )
             UpdateItemResult.Success
@@ -407,6 +408,7 @@ class AuthenticatorRepositoryImpl @Inject constructor(
             digits = digits,
             issuer = issuer,
             accountName = label,
+            favorite = favorite,
         )
     }
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/model/UpdateItemRequest.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/model/UpdateItemRequest.kt
@@ -22,6 +22,7 @@ data class UpdateItemRequest(
     val period: Int,
     val digits: Int,
     val issuer: String,
+    val favorite: Boolean,
 ) {
     /**
      * The composite label of the authenticator item. Derived from combining [issuer] and [accountName]

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -493,7 +493,8 @@ private fun EditItemContentExpandedOptionsPreview() {
                 username = "account name",
                 issuer = "issuer",
                 algorithm = AuthenticatorItemAlgorithm.SHA1,
-                digits = 6
+                digits = 6,
+                favorite = true,
             ),
             minDigitsAllowed = 5,
             maxDigitsAllowed = 10,
@@ -514,7 +515,8 @@ private fun EditItemContentCollapsedOptionsPreview() {
                 username = "account name",
                 issuer = "issuer",
                 algorithm = AuthenticatorItemAlgorithm.SHA1,
-                digits = 6
+                digits = 6,
+                favorite = false,
             ),
             minDigitsAllowed = 5,
             maxDigitsAllowed = 10,

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -64,6 +64,7 @@ import com.bitwarden.authenticator.ui.platform.components.icon.BitwardenIcon
 import com.bitwarden.authenticator.ui.platform.components.model.IconData
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.authenticator.ui.platform.components.stepper.BitwardenStepper
+import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.authenticator.ui.platform.theme.DEFAULT_FADE_TRANSITION_TIME_MS
 import com.bitwarden.authenticator.ui.platform.theme.DEFAULT_STAY_TRANSITION_TIME_MS
 import kotlinx.collections.immutable.toImmutableList
@@ -156,6 +157,13 @@ fun EditItemScreen(
                             )
                         }
                     },
+                    onToggleFavorite = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(
+                                EditItemAction.FavoriteToggleClick(it)
+                            )
+                        }
+                    },
                     onTypeOptionClicked = remember(viewModel) {
                         {
                             viewModel.trySendAction(
@@ -216,6 +224,7 @@ fun EditItemContent(
     viewState: EditItemState.ViewState.Content,
     onIssuerNameTextChange: (String) -> Unit = {},
     onUsernameTextChange: (String) -> Unit = {},
+    onToggleFavorite: (Boolean) -> Unit = {},
     onTypeOptionClicked: (AuthenticatorItemType) -> Unit = {},
     onTotpCodeTextChange: (String) -> Unit = {},
     onAlgorithmOptionClicked: (AuthenticatorItemAlgorithm) -> Unit = {},
@@ -272,9 +281,22 @@ fun EditItemContent(
                     singleLine = true,
                 )
             }
+
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                BitwardenSwitch(
+                    label = stringResource(id = R.string.favorite),
+                    isChecked = viewState.itemData.favorite,
+                    onCheckedChange = onToggleFavorite,
+                    modifier = Modifier
+                        .testTag("ItemFavoriteToggle")
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+            }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         AdvancedOptions(
             modifier = Modifier

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
@@ -64,6 +64,7 @@ class EditItemViewModel @Inject constructor(
             is EditItemAction.TypeOptionClick -> handleTypeOptionClick(action)
             is EditItemAction.IssuerNameTextChange -> handleIssuerNameTextChange(action)
             is EditItemAction.UsernameTextChange -> handleIssuerTextChange(action)
+            is EditItemAction.FavoriteToggleClick -> handleFavoriteToggleClick(action)
             is EditItemAction.RefreshPeriodOptionClick -> handlePeriodTextChange(action)
             is EditItemAction.TotpCodeTextChange -> handleTotpCodeTextChange(action)
             is EditItemAction.NumberOfDigitsOptionClick -> handleNumberOfDigitsOptionChange(action)
@@ -131,6 +132,7 @@ class EditItemViewModel @Inject constructor(
                     period = content.itemData.refreshPeriod.seconds,
                     digits = content.itemData.digits,
                     issuer = content.itemData.issuer.trim(),
+                    favorite = content.itemData.favorite,
                 )
             )
             trySendAction(EditItemAction.Internal.UpdateItemResult(result))
@@ -157,6 +159,14 @@ class EditItemViewModel @Inject constructor(
         updateItemData { currentItemData ->
             currentItemData.copy(
                 username = action.username
+            )
+        }
+    }
+
+    private fun handleFavoriteToggleClick(action: EditItemAction.FavoriteToggleClick) {
+        updateItemData { currentItemData ->
+            currentItemData.copy(
+                favorite = action.favorite
             )
         }
     }
@@ -339,6 +349,7 @@ class EditItemViewModel @Inject constructor(
             issuer = issuer,
             algorithm = algorithm,
             digits = digits,
+            favorite = favorite,
         ),
     )
     //endregion Utility Functions
@@ -466,6 +477,11 @@ sealed class EditItemAction {
     data class UsernameTextChange(val username: String) : EditItemAction()
 
     /**
+     * The user toggled the favorite checkbox.
+     */
+    data class FavoriteToggleClick(val favorite: Boolean) : EditItemAction()
+
+    /**
      * The user has selected an Item Type option.
      */
     data class TypeOptionClick(val typeOption: AuthenticatorItemType) : EditItemAction()
@@ -530,4 +546,3 @@ enum class AuthenticatorRefreshPeriodOption(val seconds: Int) {
         fun fromSeconds(seconds: Int) = entries.find { it.seconds == seconds }
     }
 }
-

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/model/EditItemData.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/model/EditItemData.kt
@@ -25,4 +25,5 @@ data class EditItemData(
     val issuer: String,
     val algorithm: AuthenticatorItemAlgorithm,
     val digits: Int,
+    val favorite: Boolean,
 ) : Parcelable

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -57,6 +59,7 @@ import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenTwoBut
 import com.bitwarden.authenticator.ui.platform.components.dialog.LoadingDialogState
 import com.bitwarden.authenticator.ui.platform.components.fab.ExpandableFabIcon
 import com.bitwarden.authenticator.ui.platform.components.fab.ExpandableFloatingActionButton
+import com.bitwarden.authenticator.ui.platform.components.header.BitwardenListHeaderTextWithSupportLabel
 import com.bitwarden.authenticator.ui.platform.components.model.IconResource
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
@@ -347,6 +350,48 @@ private fun ItemListingContent(
                 .padding(paddingValues),
         ) {
             LazyColumn {
+                if (state.favoriteItems.isNotEmpty()) {
+                    item {
+                        BitwardenListHeaderTextWithSupportLabel(
+                            label = stringResource(id = R.string.favorites),
+                            supportingLabel = state.favoriteItems.count().toString(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                        )
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+
+                    items(state.favoriteItems) {
+                        VaultVerificationCodeItem(
+                            authCode = it.authCode,
+                            name = it.issuer,
+                            username = it.username,
+                            periodSeconds = it.periodSeconds,
+                            timeLeftSeconds = it.timeLeftSeconds,
+                            alertThresholdSeconds = it.alertThresholdSeconds,
+                            startIcon = it.startIcon,
+                            onItemClick = { onItemClick(it.authCode) },
+                            onEditItemClick = { onEditItemClick(it.id) },
+                            onDeleteItemClick = { onDeleteItemClick(it.id) },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+
+                    item {
+                        HorizontalDivider(
+                            thickness = 1.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(all = 16.dp),
+                        )
+                    }
+                }
+
                 items(state.itemList) {
                     VaultVerificationCodeItem(
                         authCode = it.authCode,
@@ -359,9 +404,7 @@ private fun ItemListingContent(
                         onItemClick = { onItemClick(it.authCode) },
                         onEditItemClick = { onEditItemClick(it.id) },
                         onDeleteItemClick = { onDeleteItemClick(it.id) },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
             }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -440,6 +440,7 @@ class ItemListingViewModel @Inject constructor(
                 digits = digits,
                 issuer = issuer,
                 userId = null,
+                favorite = false,
             )
         } catch (e: Throwable) {
             return null

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -492,6 +492,7 @@ data class ItemListingState(
          */
         @Parcelize
         data class Content(
+            val favoriteItems: List<VerificationCodeDisplayItem>,
             val itemList: List<VerificationCodeDisplayItem>,
         ) : ViewState()
 

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
@@ -76,7 +76,10 @@ fun VaultVerificationCodeItem(
                     }
                 )
                 .defaultMinSize(minHeight = 72.dp)
-                .padding(vertical = 8.dp)
+                .padding(
+                    vertical = 8.dp,
+                    horizontal = 16.dp
+                )
                 .then(modifier),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/model/VerificationCodeDisplayItem.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/model/VerificationCodeDisplayItem.kt
@@ -18,4 +18,5 @@ data class VerificationCodeDisplayItem(
     val alertThresholdSeconds: Int,
     val authCode: String,
     val startIcon: IconData = IconData.Local(R.drawable.ic_login_item),
+    val favorite: Boolean,
 ) : Parcelable

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
@@ -11,7 +11,15 @@ fun List<VerificationCodeItem>.toViewState(
         ItemListingState.ViewState.NoItems
     } else {
         ItemListingState.ViewState.Content(
-            map { it.toDisplayItem(alertThresholdSeconds = alertThresholdSeconds) },
+            favoriteItems = this
+                .filter { it.favorite }
+                .map {
+                    it.toDisplayItem(alertThresholdSeconds = alertThresholdSeconds)
+                },
+            itemList = filterNot { it.favorite }
+                .map {
+                    it.toDisplayItem(alertThresholdSeconds = alertThresholdSeconds)
+                },
         )
     }
 
@@ -24,4 +32,5 @@ fun VerificationCodeItem.toDisplayItem(alertThresholdSeconds: Int) =
         periodSeconds = periodSeconds,
         alertThresholdSeconds = alertThresholdSeconds,
         authCode = code,
+        favorite = favorite,
     )

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -117,7 +117,8 @@ class ManualCodeEntryViewModel @Inject constructor(
                         AuthenticatorItemType.STEAM
                     } else {
                         AuthenticatorItemType.TOTP
-                    }
+                    },
+                    favorite = false,
                 )
             )
             sendAction(ManualCodeEntryAction.Internal.CreateItemResultReceive(result))

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/header/BitwardenListHeaderTextWithSupportLabel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/header/BitwardenListHeaderTextWithSupportLabel.kt
@@ -1,0 +1,62 @@
+package com.bitwarden.authenticator.ui.platform.components.header
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
+
+/**
+ * Represents a Bitwarden-styled label text.
+ *
+ * @param label The text content for the label.
+ * @param supportingLabel The text for the supporting label.
+ * @param modifier The [Modifier] to be applied to the label.
+ */
+@Composable
+fun BitwardenListHeaderTextWithSupportLabel(
+    label: String,
+    supportingLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .padding(
+                top = 12.dp,
+                bottom = 4.dp,
+                end = 8.dp,
+            )
+            .semantics(mergeDescendants = true) { },
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Text(
+            text = supportingLabel,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitwardenListHeaderTextWithSupportLabel_preview() {
+    AuthenticatorTheme {
+        BitwardenListHeaderTextWithSupportLabel(
+            label = "Sample Label",
+            supportingLabel = "0",
+            modifier = Modifier,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/toggle/BitwardenSwitch.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/toggle/BitwardenSwitch.kt
@@ -1,0 +1,118 @@
+package com.bitwarden.authenticator.ui.platform.components.toggle
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Represents a Bitwarden-styled [Switch].
+ *
+ * @param label The label for the switch.
+ * @param isChecked Whether or not the switch is currently checked.
+ * @param onCheckedChange A callback for when the checked state changes.
+ * @param modifier The [Modifier] to be applied to the button.
+ * @param description The description of the switch to be displayed below the [label].
+ */
+@Composable
+fun BitwardenSwitch(
+    label: String,
+    isChecked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+) {
+    Row(
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .run {
+                if (onCheckedChange != null) {
+                    this.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = rememberRipple(color = MaterialTheme.colorScheme.primary),
+                        onClick = { onCheckedChange.invoke(!isChecked) },
+                    )
+                } else {
+                    this
+                }
+            }
+            .semantics(mergeDescendants = true) {
+                toggleableState = ToggleableState(isChecked)
+            }
+            .then(modifier),
+    ) {
+        Switch(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .height(32.dp)
+                .width(52.dp),
+            checked = isChecked,
+            onCheckedChange = null,
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            description?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitwardenSwitch_preview_isChecked() {
+    BitwardenSwitch(
+        label = "Label",
+        description = "Description",
+        isChecked = true,
+        onCheckedChange = {},
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitwardenSwitch_preview_isNotChecked() {
+    BitwardenSwitch(
+        label = "Label",
+        isChecked = false,
+        onCheckedChange = {},
+        modifier = Modifier.fillMaxWidth(),
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,4 +112,7 @@
     <string name="import_vault">Import</string>
     <string name="import_success">Vault import successful</string>
     <string name="key_is_invalid">Key is invalid.</string>
+    <string name="favorite_tooltip">Save as a favorite</string>
+    <string name="favorite">Favorite</string>
+    <string name="favorites">Favorites</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Allow users to mark items as favorites. Items marked as favorites will be grouped at the top of the item listing screen.

## 📸 Screenshots

<img width="268" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/48302be2-c1a1-45eb-8f56-09e2d826bdbc">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
