### PR TITLE
Force scanned codes to uppercase alpha characters

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanViewModel.kt
@@ -1,6 +1,8 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.qrcodescan
 
 import android.net.Uri
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toUpperCase
 import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.TotpCodeResult
@@ -53,8 +55,12 @@ class QrCodeScanViewModel @Inject constructor(
         }
 
         val scannedCodeUri = Uri.parse(scannedCode)
-        val secretValue = scannedCodeUri.getQueryParameter(TotpCodeManager.SECRET_PARAM)
-        if (secretValue == null || !secretValue.isBase32()) {
+        val secretValue = scannedCodeUri
+            .getQueryParameter(TotpCodeManager.SECRET_PARAM)
+            .orEmpty()
+            .toUpperCase(Locale.current)
+
+        if (secretValue.isEmpty() || !secretValue.isBase32()) {
             authenticatorRepository.emitTotpCodeResult(TotpCodeResult.CodeScanningError)
             sendEvent(QrCodeScanEvent.NavigateBack)
             return


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Secret code characters are transformed into uppercase when scanned from a QR code. This ensures Base32 evaluation passes when scanned codes are received in lowercase.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
