### PR TITLE
[BWA-12] Update workflow to accept custom inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,20 @@ on:
     paths-ignore:
       - ".github/workflows/**"
   workflow_dispatch:
+    inputs:
+      version-name:
+        description: 'Optional. Version string to use, in X.Y.Z format. Overrides default in the project.'
+        required: false
+        type: string
+      version-code:
+        description: 'Optional. Build number to use. Overrides default of GitHub run number.'
+        required: false
+        type: number
+      publish-to-play-store:
+        description: 'Optional. Deploy bundle artifact to Google Play Store'
+        required: false
+        default: false
+        type: boolean
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,8 +178,11 @@ jobs:
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |
+          DEFAULT_VERSION_CODE=$GITHUB_RUN_NUMBER
           bundle exec fastlane setBuildVersionInfo \
-          serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }}
+          serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }} \
+          versionCode:${{ inputs.version-code || '$DEFAULT_VERSION_CODE' }} \
+          versionName:${{ inputs.version-name }}
         shell: bash
 
       - name: Assemble Release APK
@@ -204,7 +221,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
-      - name: Publish release APK to Firebase
+      - name: Distribute release APK to Firebase
         if: ${{ github.ref_name == 'main' && matrix.variant == 'apk' }}
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
@@ -255,11 +272,13 @@ jobs:
           serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }}
         shell: bash
 
-#      - name: Publish release AAB to Google Play Store
-#        if: ${{ github.ref_name == 'main' && matrix.variant == 'aab'}}
-#        env:
-#          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
-#        run: |
-#          bundle exec fastlane publishReleaseToGooglePlayStore \
-#          serviceCredentialsFile:${{ env.PLAY_STORE_CREDS_FILE }} \
-#        shell: bash
+      # Only publish bundles to Play Store when `publish-to-play-store` is true while building
+      # bundles
+      - name: Publish release AAB to Google Play Store
+        if: ${{ inputs.publish-to-play-store && matrix.variant == 'aab' }}
+        env:
+          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
+        run: |
+          bundle exec fastlane publishReleaseToGooglePlayStore \
+          serviceCredentialsFile:${{ env.PLAY_STORE_CREDS_FILE }} \
+        shell: bash

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,45 +26,30 @@ platform :android do
   fastlane_require "time"
   lane :setBuildVersionInfo do |options|
 
-    latestRelease = firebase_app_distribution_get_latest_release(
-      app: "1:867301491091:android:50b626dba42a361651e866",
-      service_credentials_file:options[:serviceCredentialsFile]
-    )
-
-    currentVersionName = latestRelease[:displayVersion]
-
-    # Gather current version information
-    versionParts = currentVersionName.split(".")
-    currentMajor = versionParts[0]
-    currentMinor = versionParts[1]
-    currentRevision = versionParts[2]
-
-    # Current date used to derive next version name.
-    currentDate = Time.new
-    major = currentDate.year.to_s
-    minor = currentDate.strftime "%m"
-
-    # Determine the next revision number to apply.
-    revision = 0
-    if currentMajor == major and currentMinor == minor
-        revision = currentRevision.to_i + 1
-    end
-
-    # Cache next version information
-    nextVersionName = major.to_s + "." + minor.to_s + "." + revision.to_s
-    nextVersionCode = latestRelease[:buildVersion].to_i + 1
-
-    # Read in app build config file.
+    # Read-in app build config file.
     buildConfigPath = "../app/build.gradle.kts"
     buildConfigFile = File.open(buildConfigPath)
     buildConfigText = buildConfigFile.read
     buildConfigFile.close
 
+    if options[:versionName].nil? or options[:versionName].to_s.empty?
+        # Use the latest version name in Firebase as the default version name.
+        latestRelease = firebase_app_distribution_get_latest_release(
+          app: "1:867301491091:android:50b626dba42a361651e866",
+          service_credentials_file:options[:serviceCredentialsFile]
+        )
+        nextVersionName = latestRelease[:displayVersion]
+    else
+        nextVersionName = options[:versionName].to_s
+    end
+
     # Replace version information.
-    puts "Setting version code to #{nextVersionCode}."
-    buildConfigText.gsub!("versionCode = 1", "versionCode = #{nextVersionCode}")
+    currentVersionCode = buildConfigText.match(/versionCode = (\d+)/).captures[0]
+    currentVersionName = buildConfigText.match(/versionName = "(.+)"/).captures[0]
+    puts "Setting version code to #{options[:versionCode]}."
+    buildConfigText.gsub!("versionCode = #{currentVersionCode}", "versionCode = #{options[:versionCode]}")
     puts "Setting version name to #{nextVersionName}."
-    buildConfigText.gsub!("versionName = \"1.0\"", "versionName = \"#{nextVersionName}\"")
+    buildConfigText.gsub!("versionName = \"#{currentVersionName}\"", "versionName = \"#{nextVersionName}\"")
 
     # Save changes
     File.open(buildConfigPath, "w") { |buildConfigFile| buildConfigFile << buildConfigText }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-12

## 📔 Objective

Workflows triggered from GitHub now accept parameters to control version name, version code, and whether builds should be published to Google Play Store or not.

When version name is not provided it defaults to the version name of the latest version in Firebase.

When version code is not provided it defaults to the GitHub job run number.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
