### PR TITLE
[BWA-14] Support importing LastPass exports

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemAlgorithm.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemAlgorithm.kt
@@ -18,5 +18,11 @@ enum class AuthenticatorItemAlgorithm {
     /**
      * Authenticator item verification code uses SHA512 hash.
      */
-    SHA512
+    SHA512,
+    ;
+
+    companion object {
+        fun fromStringOrNull(value: String): AuthenticatorItemAlgorithm? =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+    }
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemType.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/entity/AuthenticatorItemType.kt
@@ -14,4 +14,10 @@ enum class AuthenticatorItemType {
      * Steam's implementation of a one time password.
      */
     STEAM,
+    ;
+
+    companion object {
+        fun fromStringOrNull(value: String): AuthenticatorItemType? =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+    }
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ImportFileFormat.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ImportFileFormat.kt
@@ -8,4 +8,5 @@ enum class ImportFileFormat(
 ) {
     BITWARDEN_JSON("application/json"),
     TWO_FAS_JSON("*/*"),
+    LAST_PASS_JSON("application/json")
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/LastPassJsonExport.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/LastPassJsonExport.kt
@@ -1,0 +1,54 @@
+package com.bitwarden.authenticator.data.platform.manager.imports.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LastPassJsonExport(
+    val deviceId: String,
+    val deviceSecret: String,
+    val localDeviceId: String,
+    val deviceName: String,
+    val version: Int,
+    val accounts: List<Account>,
+    val folders: List<Folder>,
+) {
+    @Serializable
+    data class Account(
+        @SerialName("accountID")
+        val accountId: String,
+        val issuerName: String,
+        val originalIssuerName: String,
+        val userName: String,
+        val originalUserName: String,
+        val pushNotification: Boolean,
+        val secret: String,
+        val timeStep: Int,
+        val digits: Int,
+        val creationTimestamp: Long,
+        val isFavorite: Boolean,
+        val algorithm: String,
+        val folderData: FolderData?,
+        val backupInfo: BackupInfo?,
+    ) {
+        @Serializable
+        data class FolderData(
+            val folderId: String,
+            val position: Int,
+        )
+
+        @Serializable
+        data class BackupInfo(
+            val creationDate: String,
+            val deviceOs: String,
+            val appVersion: String,
+        )
+    }
+
+    @Serializable
+    data class Folder(
+        val id: Int,
+        val name: String,
+        val isOpened: Boolean,
+    )
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/LastPassExportParser.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/LastPassExportParser.kt
@@ -1,0 +1,74 @@
+package com.bitwarden.authenticator.data.platform.manager.imports.parsers
+
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
+import com.bitwarden.authenticator.data.platform.manager.imports.model.LastPassJsonExport
+import com.bitwarden.authenticator.data.platform.util.asFailure
+import com.bitwarden.authenticator.data.platform.util.asSuccess
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.util.UUID
+
+/**
+ * An [ExportParser] responsible for transforming LastPass export files into Bitwarden Authenticator
+ * items.
+ */
+class LastPassExportParser : ExportParser {
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun parse(byteArray: ByteArray): Result<List<AuthenticatorItemEntity>> {
+        val importJson = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            explicitNulls = false
+        }
+
+        return try {
+            importJson
+                .decodeFromStream<LastPassJsonExport>(ByteArrayInputStream(byteArray))
+                .asSuccess()
+                .mapCatching { exportData ->
+                    exportData
+                        .accounts
+                        .toAuthenticatorItemEntities()
+                }
+        } catch (e: SerializationException) {
+            e.asFailure()
+        } catch (e: IllegalArgumentException) {
+            e.asFailure()
+        } catch (e: IOException) {
+            e.asFailure()
+        }
+    }
+
+    private fun List<LastPassJsonExport.Account>.toAuthenticatorItemEntities() =
+        map { it.toAuthenticatorItemEntity() }
+
+    private fun LastPassJsonExport.Account.toAuthenticatorItemEntity(): AuthenticatorItemEntity {
+
+        // Lastpass only supports TOTP codes.
+        val type = AuthenticatorItemType.TOTP
+
+        val algorithmEnum = AuthenticatorItemAlgorithm
+            .fromStringOrNull(algorithm)
+            ?: throw IllegalArgumentException("Unsupported algorithm.")
+
+        return AuthenticatorItemEntity(
+            id = UUID.randomUUID().toString(),
+            key = secret,
+            type = type,
+            algorithm = algorithmEnum,
+            period = timeStep,
+            digits = digits,
+            issuer = originalIssuerName,
+            userId = null,
+            accountName = originalUserName,
+            favorite = isFavorite,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ImportFormatExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ImportFormatExtensions.kt
@@ -12,4 +12,5 @@ val ImportFileFormat.displayLabel: Text
     get() = when (this) {
         ImportFileFormat.BITWARDEN_JSON -> R.string.import_format_label_bitwarden_json.asText()
         ImportFileFormat.TWO_FAS_JSON -> R.string.import_format_label_2fas_json.asText()
+        ImportFileFormat.LAST_PASS_JSON -> R.string.import_format_label_lastpass_json.asText()
     }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -4,4 +4,5 @@
     <string name="export_format_label_csv">.csv</string>
     <string name="import_format_label_bitwarden_json">Bitwarden (.json)</string>
     <string name="import_format_label_2fas_json">2FAS (.2fas)</string>
+    <string name="import_format_label_lastpass_json">LastPass (.json)</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-14

## 📔 Objective

Allow users to import their unencrypted LastPass exports in JSON format.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
