### PR TITLE
[BWA-22] Prevent FAB from hiding verification codes

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -407,6 +407,12 @@ private fun ItemListingContent(
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
+
+                // Add a spacer item to prevent the FAB from hiding verification codes at the
+                // bottom of the list
+                item {
+                    Spacer(Modifier.height(72.dp))
+                }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-22
https://github.com/bitwarden/authenticator-android/issues/88

## 📔 Objective

Prevent the FAB from hiding verification codes at the bottom of the item listing screen.

Resolves #88

## 📸 Screenshots

<img width="369" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/61d69829-6cb2-4c13-919e-f90e50aaf53d">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
