### PR TITLE
[BWA-18] Add Backup option to settings

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -91,6 +91,12 @@ fun SettingsScreen(
             SettingsEvent.NavigateToTutorial -> onNavigateToTutorial()
             SettingsEvent.NavigateToExport -> onNavigateToExport()
             SettingsEvent.NavigateToImport -> onNavigateToImport()
+            SettingsEvent.NavigateToBackup -> {
+                intentManager.launchUri(
+                    uri = "https://support.google.com/android/answer/2819582".toUri(),
+                )
+            }
+
             SettingsEvent.NavigateToHelpCenter -> {
                 intentManager.launchUri("https://bitwarden.com/help".toUri())
             }
@@ -133,14 +139,19 @@ fun SettingsScreen(
             VaultSettings(
                 onExportClick = remember(viewModel) {
                     {
-                        viewModel.trySendAction(SettingsAction.VaultClick.ExportClick)
+                        viewModel.trySendAction(SettingsAction.DataClick.ExportClick)
                     }
                 },
                 onImportClick = remember(viewModel) {
                     {
-                        viewModel.trySendAction(SettingsAction.VaultClick.ImportClick)
+                        viewModel.trySendAction(SettingsAction.DataClick.ImportClick)
                     }
                 },
+                onBackupClick = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(SettingsAction.DataClick.BackupClick)
+                    }
+                }
             )
             Spacer(modifier = Modifier.height(16.dp))
             AppearanceSettings(
@@ -230,17 +241,18 @@ fun SecuritySettings(
 
 //endregion
 
-//region Vault settings
+//region Data settings
 
 @Composable
 fun VaultSettings(
     modifier: Modifier = Modifier,
     onExportClick: () -> Unit,
     onImportClick: () -> Unit,
+    onBackupClick: () -> Unit,
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.vault)
+        label = stringResource(id = R.string.data)
     )
     Spacer(modifier = Modifier.height(8.dp))
     BitwardenTextRow(
@@ -275,6 +287,15 @@ fun VaultSettings(
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    BitwardenExternalLinkRow(
+        text = stringResource(R.string.backup),
+        onConfirmClick = onBackupClick,
+        dialogTitle = stringResource(R.string.data_backup_title),
+        dialogMessage = stringResource(R.string.data_backup_message),
+        dialogConfirmButtonText = stringResource(R.string.learn_more),
+        dialogDismissButtonText = stringResource(R.string.ok),
     )
 }
 
@@ -313,7 +334,7 @@ private fun UnlockWithBiometricsRow(
     )
 }
 
-//endregion Vault settings
+//endregion Data settings
 
 //region Appearance settings
 

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
@@ -51,7 +51,7 @@ class SettingsViewModel @Inject constructor(
                 handleSecurityClick(action)
             }
 
-            is SettingsAction.VaultClick -> {
+            is SettingsAction.DataClick -> {
                 handleVaultClick(action)
             }
 
@@ -125,10 +125,11 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    private fun handleVaultClick(action: SettingsAction.VaultClick) {
+    private fun handleVaultClick(action: SettingsAction.DataClick) {
         when (action) {
-            SettingsAction.VaultClick.ExportClick -> handleExportClick()
-            SettingsAction.VaultClick.ImportClick -> handleImportClick()
+            SettingsAction.DataClick.ExportClick -> handleExportClick()
+            SettingsAction.DataClick.ImportClick -> handleImportClick()
+            SettingsAction.DataClick.BackupClick -> handleBackupClick()
         }
     }
 
@@ -138,6 +139,10 @@ class SettingsViewModel @Inject constructor(
 
     private fun handleImportClick() {
         sendEvent(SettingsEvent.NavigateToImport)
+    }
+
+    private fun handleBackupClick() {
+        sendEvent(SettingsEvent.NavigateToBackup)
     }
 
     private fun handleAppearanceChange(action: SettingsAction.AppearanceChange) {
@@ -299,6 +304,11 @@ sealed class SettingsEvent {
     data object NavigateToImport : SettingsEvent()
 
     /**
+     * Navigate to the Backup web page.
+     */
+    data object NavigateToBackup : SettingsEvent()
+
+    /**
      * Navigate to the Help Center web page.
      */
     data object NavigateToHelpCenter : SettingsEvent()
@@ -322,7 +332,7 @@ sealed class SettingsAction(
     sealed class Dialog {
 
         /**
-         *
+         * Display the loading screen with a [message].
          */
         data class Loading(
             val message: Text,
@@ -339,17 +349,22 @@ sealed class SettingsAction(
     /**
      * Models actions for the Vault section of settings.
      */
-    sealed class VaultClick : SettingsAction() {
+    sealed class DataClick : SettingsAction() {
 
         /**
          * Indicates the user clicked export.
          */
-        data object ExportClick : VaultClick()
+        data object ExportClick : DataClick()
 
         /**
          * Indicates the user clicked import.
          */
-        data object ImportClick : VaultClick()
+        data object ImportClick : DataClick()
+
+        /**
+         * Indicates the user click backup.
+         */
+        data object BackupClick : DataClick()
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="item_deleted">Item deleted</string>
     <string name="delete">Delete</string>
     <string name="do_you_really_want_to_permanently_delete_cipher">Do you really want to permanently delete? This cannot be undone.</string>
-    <string name="vault">Vault</string>
+    <string name="data">Data</string>
     <string name="export">Export</string>
     <string name="loading">Loading</string>
     <string name="export_confirmation_title">Confirm export</string>
@@ -115,4 +115,8 @@
     <string name="favorite_tooltip">Save as a favorite</string>
     <string name="favorite">Favorite</string>
     <string name="favorites">Favorites</string>
+    <string name="backup">Backup</string>
+    <string name="data_backup_title">Data backup</string>
+    <string name="data_backup_message">Bitwarden Authenticator data is backed up and can be restored with your regularly scheduled device backups.</string>
+    <string name="learn_more">Learn more</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-18

## 📔 Objective

Add the Backup option to settings. When clicked it describes how app data is backed up using the native device backup mechanisms and provides a link to the official documentation.

## 📸 Screenshots

<img width="374" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/883dc20d-9aeb-41fd-b11e-253d74c3c78e">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
