### PR TITLE
Remove language switcher

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -50,8 +50,6 @@ import com.bitwarden.authenticator.ui.platform.base.util.Text
 import com.bitwarden.authenticator.ui.platform.base.util.asText
 import com.bitwarden.authenticator.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.authenticator.ui.platform.components.appbar.BitwardenMediumTopAppBar
-import com.bitwarden.authenticator.ui.platform.components.dialog.BasicDialogState
-import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenSelectionRow
 import com.bitwarden.authenticator.ui.platform.components.header.BitwardenListHeaderText
@@ -60,7 +58,6 @@ import com.bitwarden.authenticator.ui.platform.components.row.BitwardenTextRow
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenWideSwitch
 import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
-import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
@@ -156,11 +153,6 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(16.dp))
             AppearanceSettings(
                 state = state,
-                onLanguageSelection = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.AppearanceChange.LanguageChange(it))
-                    }
-                },
                 onThemeSelection = remember(viewModel) {
                     {
                         viewModel.trySendAction(SettingsAction.AppearanceChange.ThemeChange(it))
@@ -341,7 +333,6 @@ private fun UnlockWithBiometricsRow(
 @Composable
 private fun AppearanceSettings(
     state: SettingsState,
-    onLanguageSelection: (language: AppLanguage) -> Unit,
     onThemeSelection: (theme: AppTheme) -> Unit,
 ) {
     BitwardenListHeaderText(
@@ -355,69 +346,6 @@ private fun AppearanceSettings(
             .semantics { testTag = "ThemeChooser" }
             .fillMaxWidth(),
     )
-
-    LanguageSelectionRow(
-        currentSelection = state.appearance.language,
-        onLanguageSelection = onLanguageSelection,
-        modifier = Modifier
-            .semantics { testTag = "LanguageChooser" }
-            .fillMaxWidth(),
-    )
-}
-
-@Composable
-private fun LanguageSelectionRow(
-    currentSelection: AppLanguage,
-    onLanguageSelection: (AppLanguage) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var languageChangedDialogState: BasicDialogState by rememberSaveable {
-        mutableStateOf(BasicDialogState.Hidden)
-    }
-    var shouldShowLanguageSelectionDialog by rememberSaveable { mutableStateOf(false) }
-
-    BitwardenBasicDialog(
-        visibilityState = languageChangedDialogState,
-        onDismissRequest = { languageChangedDialogState = BasicDialogState.Hidden },
-    )
-
-    BitwardenTextRow(
-        text = stringResource(id = R.string.language),
-        onClick = { shouldShowLanguageSelectionDialog = true },
-        modifier = modifier,
-        withDivider = true,
-    ) {
-        Icon(
-            modifier = Modifier
-                .mirrorIfRtl()
-                .size(24.dp),
-            painter = painterResource(id = R.drawable.ic_navigate_next),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-        )
-    }
-
-    if (shouldShowLanguageSelectionDialog) {
-        BitwardenSelectionDialog(
-            title = stringResource(id = R.string.language),
-            onDismissRequest = { shouldShowLanguageSelectionDialog = false },
-        ) {
-            AppLanguage.entries.forEach { option ->
-                BitwardenSelectionRow(
-                    text = option.text,
-                    isSelected = option == currentSelection,
-                    onClick = {
-                        shouldShowLanguageSelectionDialog = false
-                        onLanguageSelection(option)
-                        languageChangedDialogState = BasicDialogState.Shown(
-                            title = R.string.language.asText(),
-                            message = R.string.language_change_x_description.asText(option.text),
-                        )
-                    },
-                )
-            }
-        }
-    }
 }
 
 @Composable


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 📔 Objective

Remove the language selector from Settings since we do not currently have translations for other languages.

## 📸 Screenshots

<img width="376" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/d4a59b22-a3cc-4e77-813b-88a89a6bf1df">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
