### PR TITLE
Display a descriptive error when import fails

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
@@ -250,10 +250,16 @@ class AuthenticatorRepositoryImpl @Inject constructor(
         format: ImportFileFormat,
         fileData: IntentManager.FileData,
     ): ImportDataResult = fileManager.uriToByteArray(fileData.uri)
-        .map { importManager.import(importFileFormat = format, byteArray = it) }
+        .map {
+            importManager
+                .import(
+                    importFileFormat = format,
+                    byteArray = it
+                )
+        }
         .fold(
             onSuccess = { it },
-            onFailure = { ImportDataResult.Error }
+            onFailure = { ImportDataResult.Error() }
         )
 
     private suspend fun encodeVaultDataToCsv(fileUri: Uri): ExportDataResult {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ExportParseResult.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ExportParseResult.kt
@@ -1,0 +1,22 @@
+package com.bitwarden.authenticator.data.platform.manager.imports.model
+
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import com.bitwarden.authenticator.ui.platform.base.util.Text
+
+/**
+ * Represents the result of parsing an export file.
+ */
+sealed class ExportParseResult {
+
+    /**
+     * Indicates the selected file has been successfully parsed.
+     */
+    data class Success(val items: List<AuthenticatorItemEntity>) : ExportParseResult()
+
+    /**
+     * Indicates there was an error while parsing the selected file.
+     *
+     * @property message User friendly message displayed to the user, if provided.
+     */
+    data class Error(val message: Text? = null) : ExportParseResult()
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ImportDataResult.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/ImportDataResult.kt
@@ -1,10 +1,12 @@
 package com.bitwarden.authenticator.data.platform.manager.imports.model
 
+import com.bitwarden.authenticator.ui.platform.base.util.Text
+
 /**
  * Represents the result of a data import operation.
  */
 sealed class ImportDataResult {
     data object Success : ImportDataResult()
 
-    data object Error : ImportDataResult()
+    data class Error(val message: Text? = null) : ImportDataResult()
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/TwoFasJsonExport.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/model/TwoFasJsonExport.kt
@@ -8,6 +8,7 @@ data class TwoFasJsonExport(
     val appVersionCode: Int,
     val appOrigin: String,
     val services: List<Service>,
+    val servicesEncrypted: String?,
     val groups: List<Group>,
 ) {
     @Serializable

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/ExportParser.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/ExportParser.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.authenticator.data.platform.manager.imports.parsers
 
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import com.bitwarden.authenticator.data.platform.manager.imports.model.ExportParseResult
 
 /**
  * Responsible for transforming exported authenticator data to a format consumable by this
@@ -12,5 +13,5 @@ interface ExportParser {
      * Converts the given [byteArray] content of a file to a collection of
      * [AuthenticatorItemEntity].
      */
-    fun parse(byteArray: ByteArray): Result<List<AuthenticatorItemEntity>>
+    fun parse(byteArray: ByteArray): ExportParseResult
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
@@ -74,7 +74,8 @@ class ImportingViewModel @Inject constructor(
     private fun handleImportLocationReceive(action: ImportAction.ImportLocationReceive) {
         mutableStateFlow.update { it.copy(dialogState = ImportState.DialogState.Loading()) }
         viewModelScope.launch {
-            val result = authenticatorRepository.importVaultData(state.importFileFormat, action.fileUri)
+            val result =
+                authenticatorRepository.importVaultData(state.importFileFormat, action.fileUri)
             sendAction(ImportAction.Internal.SaveImportDataToUriResultReceive(result))
         }
     }
@@ -89,12 +90,13 @@ class ImportingViewModel @Inject constructor(
 
     private fun handleSaveImportDataToUriResultReceive(result: ImportDataResult) {
         when (result) {
-            ImportDataResult.Error -> {
+            is ImportDataResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ImportState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.import_vault_failure.asText(),
+                            message = result.message
+                                ?: R.string.import_vault_failure.asText(),
                         )
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,4 +119,6 @@
     <string name="data_backup_title">Data backup</string>
     <string name="data_backup_message">Bitwarden Authenticator data is backed up and can be restored with your regularly scheduled device backups.</string>
     <string name="learn_more">Learn more</string>
+    <string name="import_2fas_password_protected_not_supported">Importing from 2FAS password protected files is not supported. Try again with an exported file that is not password protected.</string>
+    <string name="import_bitwarden_unsupported_format">Importing Bitwarden CSV files is not supported. Try again with an exported JSON file.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

When an import operation fails the user will see a message explaining the failure, when a description is warranted. In paricular this displays a descriptive message when the user attempts to import password protected file from 2FAS or a Bitwarden CSV file.

## 📸 Screenshots

<img width="372" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/e734738f-da15-4135-a6ac-68ea52cb0010">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
