### PR TITLE
Update 2FAS import option label

### DIFF
--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -3,7 +3,7 @@
     <string name="export_format_label_json">.json</string>
     <string name="export_format_label_csv">.csv</string>
     <string name="import_format_label_bitwarden_json">Bitwarden (.json)</string>
-    <string name="import_format_label_2fas_json">2FAS (.2fas)</string>
+    <string name="import_format_label_2fas_json">2FAS (no password)</string>
     <string name="import_format_label_lastpass_json">LastPass (.json)</string>
     <string name="import_format_label_aegis_json">Aegis (.json)</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 📔 Objective

Rename the 2FAS import option so that it clearly indicates files should not be password protected.

## 📸 Screenshots

<img width="376" alt="image" src="https://github.com/bitwarden/authenticator-android/assets/1883101/02a38424-b1c5-4878-a4f1-7b5396bdc1ea">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
