### PR TITLE
Extract account name from Aegis imports

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/AegisExportParser.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/AegisExportParser.kt
@@ -45,13 +45,25 @@ class AegisExportParser : ExportParser {
 
     private fun AegisJsonExport.Database.Entry.toAuthenticatorItemEntity(): AuthenticatorItemEntity {
 
-        // Lastpass only supports TOTP codes.
+        // Aegis only supports TOTP codes.
         val type = AuthenticatorItemType.fromStringOrNull(type)
             ?: throw IllegalArgumentException("Unsupported OTP type")
 
         val algorithmEnum = AuthenticatorItemAlgorithm
             .fromStringOrNull(info.algo)
             ?: throw IllegalArgumentException("Unsupported algorithm.")
+
+        val issuer = issuer
+            .takeUnless { it.isEmpty() }
+        // If issuer is not provided we fallback to the account name.
+            ?: name
+                .split(":")
+                .first()
+        val accountName = name
+            .split(":")
+            .last()
+            // If the account name matches the derived issuer we ignore it to prevent redundancy.
+            .takeUnless { it == issuer }
 
         return AuthenticatorItemEntity(
             id = UUID.randomUUID().toString(),
@@ -62,7 +74,7 @@ class AegisExportParser : ExportParser {
             digits = info.digits,
             issuer = issuer,
             userId = null,
-            accountName = name,
+            accountName = accountName,
             favorite = favorite,
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-41

## 📔 Objective

When importing from Aegis the username will be properly extracted if the name field contains both label and account name.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
