### PR TITLE
[BWA-10] Sanitize launch intents before processing

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/IntentExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/IntentExtensions.kt
@@ -1,0 +1,13 @@
+package com.bitwarden.authenticator.data.platform.util
+
+import android.content.Intent
+
+/**
+ * Returns true if this intent contains unexpected or suspicious data.
+ */
+val Intent.isSuspicious: Boolean
+    get() {
+        val containsSuspiciousExtras = extras?.isEmpty?.not() ?: false
+        val containsSuspiciousData = data != null
+        return containsSuspiciousData || containsSuspiciousExtras
+    }

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/util/IntentExtensionsTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/util/IntentExtensionsTest.kt
@@ -1,0 +1,64 @@
+package com.bitwarden.authenticator.data.platform.util
+
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntentExtensionsTest {
+    @Test
+    fun `isSuspicious should return true when extras are not empty`() {
+        val intent = mockk<Intent> {
+            every { data } returns mockk()
+            every { extras } returns mockk {
+                every { isEmpty } returns false
+            }
+        }
+
+        assertTrue(intent.isSuspicious)
+    }
+
+    @Test
+    fun `isSuspicious should return true when extras are null`() {
+        val intent = mockk<Intent> {
+            every { data } returns mockk()
+            every { extras } returns null
+        }
+
+        assertTrue(intent.isSuspicious)
+    }
+
+    @Test
+    fun `isSuspicious should return true when data is not null`() {
+        val intent = mockk<Intent> {
+            every { data } returns mockk()
+            every { extras } returns null
+        }
+
+        assertTrue(intent.isSuspicious)
+    }
+
+    @Test
+    fun `isSuspicious should return false when data and extras are null`() {
+        val intent = mockk<Intent> {
+            every { data } returns null
+            every { extras } returns null
+        }
+
+        assertFalse(intent.isSuspicious)
+    }
+
+    @Test
+    fun `isSuspicious should return false when data is null and extras are empty`() {
+        val intent = mockk<Intent> {
+            every { data } returns null
+            every { extras } returns mockk {
+                every { isEmpty } returns true
+            }
+        }
+
+        assertFalse(intent.isSuspicious)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-10

## 📔 Objective

Validate launch intent data before processing in order to prevent DOS attacks from malicious applications.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
