### PR TITLE
BITAU-158 Add PasswordManagerSync local feature flag

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FeatureFlag.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FeatureFlag.kt
@@ -29,6 +29,14 @@ sealed class LocalFeatureFlag<out T : Any>(
         name = "bitwarden-authentication-enabled",
         defaultValue = false,
     )
+
+    /**
+     * Indicates whether syncing with the main Bitwarden password manager app should be enabled.
+     */
+    data object PasswordManagerSync : LocalFeatureFlag<Boolean>(
+        name = "enable-password-manager-sync-android",
+        defaultValue = false,
+    )
 }
 
 /**

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
@@ -58,6 +58,11 @@ class FeatureFlagManagerTest {
 
         assertFalse(flagValue)
     }
+
+    @Test
+    fun `PasswordManagerSync should default to false`() {
+        assertFalse(LocalFeatureFlag.PasswordManagerSync.defaultValue)
+    }
 }
 
 private val FEATURE_FLAGS_CONFIG =


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-158

## 📔 Objective

The goal of this PR is to setup a local feature flag for password manager sync.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
