### PR TITLE
[BWA-65] Sort items alphabetically with special char precedence

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.navigation.compose)
+    testImplementation(libs.testng)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.CreateIte
 import com.bitwarden.authenticator.data.authenticator.repository.model.DeleteItemResult
 import com.bitwarden.authenticator.data.authenticator.repository.model.ExportDataResult
 import com.bitwarden.authenticator.data.authenticator.repository.model.TotpCodeResult
+import com.bitwarden.authenticator.data.authenticator.repository.util.sortAlphabetically
 import com.bitwarden.authenticator.data.platform.manager.DispatcherManager
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDataResult
@@ -113,7 +114,7 @@ class AuthenticatorRepositoryImpl @Inject constructor(
                 mutableCiphersStateFlow.value = DataState.Loading
             }
             .onEach {
-                mutableCiphersStateFlow.value = DataState.Loaded(it)
+                mutableCiphersStateFlow.value = DataState.Loaded(it.sortAlphabetically())
             }
             .launchIn(unconfinedScope)
     }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/util/AuthenticatorItemEntityExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/util/AuthenticatorItemEntityExtensions.kt
@@ -1,0 +1,17 @@
+package com.bitwarden.authenticator.data.authenticator.repository.util
+
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import com.bitwarden.authenticator.data.platform.util.SpecialCharWithPrecedenceComparator
+
+/**
+ * Sorts the data in alphabetical order by name. Using lexicographical sorting but giving
+ * precedence to special characters over letters and digits.
+ */
+@JvmName("toAlphabeticallySortedCipherList")
+fun List<AuthenticatorItemEntity>.sortAlphabetically(): List<AuthenticatorItemEntity> {
+    return this.sortedWith(
+        comparator = { cipher1, cipher2 ->
+            SpecialCharWithPrecedenceComparator.compare(cipher1.issuer, cipher2.issuer)
+        },
+    )
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/SpecialCharWithPrecedenceComparator.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/SpecialCharWithPrecedenceComparator.kt
@@ -1,0 +1,67 @@
+package com.bitwarden.authenticator.data.platform.util
+
+import java.util.Locale
+
+/**
+ * String [Comparator] where the characters are compared giving precedence to
+ * special characters.
+ */
+object SpecialCharWithPrecedenceComparator : Comparator<String> {
+    override fun compare(str1: String, str2: String): Int {
+        val minLength = minOf(str1.length, str2.length)
+        for (i in 0 until minLength) {
+            val char1 = str1[i]
+            val char2 = str2[i]
+            val compareResult = compareCharsSpecialCharsWithPrecedence(char1, char2)
+            if (compareResult != 0) {
+                return compareResult
+            }
+        }
+        // If all compared chars are the same give precedence to the shorter String.
+        return str1.length - str2.length
+    }
+}
+
+/**
+ * Compare two characters, where a special character is considered with higher precedence over
+ * letters and numbers. If both characters are a letter and they are equal ignoring the case,
+ * give priority to the lowercase instance. If they are both a digit or a non-equal letter
+ * use the default [String.compareTo] converting the chars to the [Locale] specific uppercase
+ * String.
+ */
+private fun compareCharsSpecialCharsWithPrecedence(c1: Char, c2: Char): Int {
+    return when {
+        c1.isLetterOrDigit() && !c2.isLetterOrDigit() -> 1
+        !c1.isLetterOrDigit() && c2.isLetterOrDigit() -> -1
+        c1.isLetter() && c2.isLetter() && c1.equals(other = c2, ignoreCase = true) -> {
+            compareLettersLowerCaseFirst(c1 = c1, c2 = c2)
+        }
+
+        else -> {
+            val upperCaseStr1 = c1.toString().uppercase(Locale.getDefault())
+            val upperCaseStr2 = c2.toString().uppercase(Locale.getDefault())
+            upperCaseStr1.compareTo(upperCaseStr2)
+        }
+    }
+}
+
+/**
+ * Compare two equal letters ignoring case (i.e. 'A' == 'a'), give precedence to the
+ * the character which is lowercase. If both [c1] and [c2] are equal and the
+ * same case return 0 to indicate they are the same.
+ */
+private fun compareLettersLowerCaseFirst(c1: Char, c2: Char): Int {
+    require(
+        value = c1.isLetter() &&
+            c2.isLetter() &&
+            c1.equals(other = c2, ignoreCase = true),
+    ) {
+        "Both character must be the same letter, case does not matter."
+    }
+
+    return when {
+        !c1.isLowerCase() && c2.isLowerCase() -> 1
+        c1.isLowerCase() && !c2.isLowerCase() -> -1
+        else -> 0
+    }
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
@@ -16,12 +16,10 @@ fun List<VerificationCodeItem>.toViewState(
         ItemListingState.ViewState.Content(
             favoriteItems = this
                 .filter { it.favorite }
-                .sortedBy { it.issuer }
                 .map {
                     it.toDisplayItem(alertThresholdSeconds = alertThresholdSeconds)
                 },
             itemList = filterNot { it.favorite }
-                .sortedBy { it.issuer }
                 .map {
                     it.toDisplayItem(alertThresholdSeconds = alertThresholdSeconds)
                 },

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/datasource/disk/util/FakeAuthenticatorDiskSource.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/datasource/disk/util/FakeAuthenticatorDiskSource.kt
@@ -1,0 +1,23 @@
+package com.bitwarden.authenticator.data.authenticator.datasource.disk.util
+
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.AuthenticatorDiskSource
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class FakeAuthenticatorDiskSource : AuthenticatorDiskSource {
+    private val mutableItemFlow = MutableSharedFlow<List<AuthenticatorItemEntity>>()
+    private val storedItems = mutableListOf<AuthenticatorItemEntity>()
+
+    override suspend fun saveItem(vararg authenticatorItem: AuthenticatorItemEntity) {
+        storedItems.addAll(authenticatorItem)
+        mutableItemFlow.emit(storedItems)
+    }
+
+    override fun getItems(): Flow<List<AuthenticatorItemEntity>> = mutableItemFlow
+
+    override suspend fun deleteItem(itemId: String) {
+        storedItems.removeIf { it.id == itemId }
+        mutableItemFlow.emit(storedItems)
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/datasource/entity/AuthenticatorItemEntityUtil.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/datasource/entity/AuthenticatorItemEntityUtil.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.authenticator.data.authenticator.datasource.entity
+
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
+import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
+
+fun createMockAuthenticatorItemEntity(number: Int): AuthenticatorItemEntity =
+    AuthenticatorItemEntity(
+        id = "mockId-$number",
+        key = "mockKey-$number",
+        type = AuthenticatorItemType.TOTP,
+        algorithm = TotpCodeManager.ALGORITHM_DEFAULT,
+        period = TotpCodeManager.PERIOD_SECONDS_DEFAULT,
+        digits = TotpCodeManager.TOTP_DIGITS_DEFAULT,
+        issuer = "mockIssuer-$number",
+        userId = null,
+        accountName = "mockAccountName-$number",
+        favorite = false,
+    )

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/manager/util/VerificationCodeItemUtil.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/manager/util/VerificationCodeItemUtil.kt
@@ -1,0 +1,26 @@
+package com.bitwarden.authenticator.data.authenticator.manager.util
+
+import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+
+/**
+ * Creates a mock [VerificationCodeItem] for testing purposes.
+ *
+ * @param number A number used to generate unique values for the mock item.
+ * @param favorite Whether the mock item should be marked as favorite. Defaults to false.
+ * @return A [VerificationCodeItem] with mock data based on the provided number.
+ */
+fun createMockVerificationCodeItem(
+    number: Int,
+    favorite: Boolean = false,
+): VerificationCodeItem =
+    VerificationCodeItem(
+        code = "mockCode-$number",
+        totpCode = "mockTotpCode-$number",
+        periodSeconds = 30,
+        timeLeftSeconds = 120,
+        issueTime = 0,
+        id = "mockId-$number",
+        username = "mockUsername-$number",
+        issuer = "mockIssuer-$number",
+        favorite = favorite,
+    )

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryTest.kt
@@ -1,0 +1,59 @@
+package com.bitwarden.authenticator.data.authenticator.repository
+
+import app.cash.turbine.test
+import com.bitwarden.authenticator.data.authenticator.datasource.disk.util.FakeAuthenticatorDiskSource
+import com.bitwarden.authenticator.data.authenticator.datasource.entity.createMockAuthenticatorItemEntity
+import com.bitwarden.authenticator.data.authenticator.manager.FileManager
+import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
+import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+import com.bitwarden.authenticator.data.platform.base.FakeDispatcherManager
+import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
+import com.bitwarden.authenticator.data.platform.repository.model.DataState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AuthenticatorRepositoryTest {
+
+    private val fakeAuthenticatorDiskSource = FakeAuthenticatorDiskSource()
+    private val mutableTotpCodesStateFlow =
+        MutableStateFlow<DataState<List<VerificationCodeItem>>>(DataState.Loading)
+    private val mockTotpCodeManager = mockk<TotpCodeManager> {
+        every { getTotpCodesStateFlow(any()) } returns mutableTotpCodesStateFlow
+    }
+    private val mockFileManager = mockk<FileManager>()
+    private val mockImportManager = mockk<ImportManager>()
+    private val mockDispatcherManager = FakeDispatcherManager()
+
+    private val authenticatorRepository = AuthenticatorRepositoryImpl(
+        authenticatorDiskSource = fakeAuthenticatorDiskSource,
+        totpCodeManager = mockTotpCodeManager,
+        fileManager = mockFileManager,
+        importManager = mockImportManager,
+        dispatcherManager = mockDispatcherManager,
+    )
+
+    @Test
+    fun `initial state should be correct`() = runTest {
+        authenticatorRepository.ciphersStateFlow.test {
+            assertEquals(
+                DataState.Loading,
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `ciphersStateFlow should emit sorted authenticator items when disk source changes`() =
+        runTest {
+            val mockItem = createMockAuthenticatorItemEntity(1)
+            fakeAuthenticatorDiskSource.saveItem(mockItem)
+            assertEquals(
+                DataState.Loaded(listOf(mockItem)),
+                authenticatorRepository.ciphersStateFlow.value,
+            )
+        }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/repository/util/AuthenticatorItemEntityExtensionsTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/repository/util/AuthenticatorItemEntityExtensionsTest.kt
@@ -1,0 +1,42 @@
+package com.bitwarden.authenticator.data.authenticator.repository.util
+
+import com.bitwarden.authenticator.data.authenticator.datasource.entity.createMockAuthenticatorItemEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AuthenticatorItemEntityExtensionsTest {
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toSortAlphabetically should sort ciphers by name`() {
+        val list = listOf(
+            createMockAuthenticatorItemEntity(1).copy(issuer = "c"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "B"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "z"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "8"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "7"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "_"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "A"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "D"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "AbA"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "aAb"),
+        )
+
+        val expected = listOf(
+            createMockAuthenticatorItemEntity(1).copy(issuer = "_"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "7"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "8"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "aAb"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "A"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "AbA"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "B"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "c"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "D"),
+            createMockAuthenticatorItemEntity(1).copy(issuer = "z"),
+        )
+
+        assertEquals(
+            expected,
+            list.sortAlphabetically(),
+        )
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/util/SpecialCharWithPrecedenceComparatorTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/util/SpecialCharWithPrecedenceComparatorTest.kt
@@ -1,0 +1,44 @@
+package com.bitwarden.authenticator.data.platform.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SpecialCharWithPrecedenceComparatorTest {
+
+    @Test
+    fun `Sorting with comparator should return expected result of sorted string`() {
+        val unsortedList = listOf(
+            "__Za",
+            "z",
+            "___",
+            "1a3",
+            "aBc",
+            "__a",
+            "__A",
+            "__a",
+            "__4",
+            "Z",
+            "__3",
+            "Abc",
+        )
+        val expectedSortedList = listOf(
+            "___",
+            "__3",
+            "__4",
+            "__a",
+            "__a",
+            "__A",
+            "__Za",
+            "1a3",
+            "aBc",
+            "Abc",
+            "z",
+            "Z",
+        )
+
+        assertEquals(
+            expectedSortedList,
+            unsortedList.sortedWith(SpecialCharWithPrecedenceComparator),
+        )
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensionsTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensionsTest.kt
@@ -1,0 +1,60 @@
+package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.util
+
+import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+import com.bitwarden.authenticator.data.authenticator.manager.util.createMockVerificationCodeItem
+import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.ItemListingState
+import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.VerificationCodeDisplayItem
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VerificationCodeItemExtensionsTest {
+
+    @Test
+    fun `toViewState empty list should return NoItems state`() {
+        assertEquals(
+            ItemListingState.ViewState.NoItems,
+            emptyList<VerificationCodeItem>().toViewState(alertThresholdSeconds = 7),
+        )
+    }
+
+    @Test
+    fun `toViewState non empty list should return Content state`() {
+        val favoriteItem = createMockVerificationCodeItem(number = 1, favorite = true)
+        val nonFavoriteItem = createMockVerificationCodeItem(number = 2)
+        val items = listOf(favoriteItem, nonFavoriteItem)
+
+        val expectedFavoriteItems = listOf(
+            VerificationCodeDisplayItem(
+                id = favoriteItem.id,
+                issuer = favoriteItem.issuer,
+                username = favoriteItem.username,
+                timeLeftSeconds = favoriteItem.timeLeftSeconds,
+                periodSeconds = favoriteItem.periodSeconds,
+                alertThresholdSeconds = 7,
+                authCode = favoriteItem.code,
+                favorite = favoriteItem.favorite,
+            ),
+        )
+
+        val expectedNonFavoriteItems = listOf(
+            VerificationCodeDisplayItem(
+                id = nonFavoriteItem.id,
+                issuer = nonFavoriteItem.issuer,
+                username = nonFavoriteItem.username,
+                timeLeftSeconds = nonFavoriteItem.timeLeftSeconds,
+                periodSeconds = nonFavoriteItem.periodSeconds,
+                alertThresholdSeconds = 7,
+                authCode = nonFavoriteItem.code,
+                favorite = nonFavoriteItem.favorite,
+            ),
+        )
+
+        assertEquals(
+            ItemListingState.ViewState.Content(
+                favoriteItems = expectedFavoriteItems,
+                itemList = expectedNonFavoriteItems,
+            ),
+            items.toViewState(alertThresholdSeconds = 7),
+        )
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
@@ -1,0 +1,86 @@
+package com.bitwarden.authenticator.ui.authenticator.feature.search
+
+import androidx.lifecycle.SavedStateHandle
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+import com.bitwarden.authenticator.data.authenticator.manager.util.createMockVerificationCodeItem
+import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
+import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.bitwarden.authenticator.data.platform.repository.model.DataState
+import com.bitwarden.authenticator.ui.platform.base.BaseViewModelTest
+import com.bitwarden.authenticator.ui.platform.components.model.IconData
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ItemSearchViewModelTest : BaseViewModelTest() {
+
+    private val mutableAuthCodesStateFlow =
+        MutableStateFlow<DataState<List<VerificationCodeItem>>>(DataState.Loading)
+    private val mockAuthenticatorRepository = mockk<AuthenticatorRepository> {
+        every { getAuthCodesFlow() } returns mutableAuthCodesStateFlow
+    }
+    private val mockClipboardManager = mockk<BitwardenClipboardManager>()
+
+    @Test
+    fun `initial state is correct`() {
+        val viewModel = createViewModel()
+        assertEquals(ItemSearchState.ViewState.Loading, viewModel.stateFlow.value.viewState)
+    }
+
+    @Test
+    fun `state is updated when auth codes are received`() {
+        val mockVerificationCodeItem = createMockVerificationCodeItem(number = 1)
+        val viewModel = createViewModel()
+
+        mutableAuthCodesStateFlow.value = DataState.Loaded(listOf(mockVerificationCodeItem))
+
+        viewModel.trySendAction(
+            ItemSearchAction.SearchTermChange(
+                mockVerificationCodeItem.username!!,
+            ),
+        )
+
+        assertEquals(
+            ItemSearchState.ViewState.Content(
+                displayItems = listOf(
+                    ItemSearchState.DisplayItem(
+                        id = mockVerificationCodeItem.id,
+                        authCode = mockVerificationCodeItem.code,
+                        accountName = mockVerificationCodeItem.username,
+                        issuer = mockVerificationCodeItem.issuer,
+                        periodSeconds = mockVerificationCodeItem.periodSeconds,
+                        timeLeftSeconds = mockVerificationCodeItem.timeLeftSeconds,
+                        alertThresholdSeconds = 7,
+                        startIcon = IconData.Local(iconRes = R.drawable.ic_login_item),
+                        supportingLabel = mockVerificationCodeItem.label,
+                    ),
+                ),
+            ),
+            viewModel.stateFlow.value.viewState,
+        )
+    }
+
+    private fun createItemSearchState(
+        viewState: ItemSearchState.ViewState = ItemSearchState.ViewState.Loading,
+        dialogState: ItemSearchState.DialogState? = null,
+    ) = ItemSearchState(
+        searchTerm = "",
+        viewState = viewState,
+        dialogState = dialogState,
+    )
+
+    private fun createViewModel(
+        initialState: ItemSearchState = createItemSearchState(),
+    ): ItemSearchViewModel {
+        return ItemSearchViewModel(
+            SavedStateHandle().apply {
+                set("state", initialState)
+            },
+            mockClipboardManager,
+            mockAuthenticatorRepository,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ roboelectric = "4.13"
 sonarqube = "5.1.0.4882" 
 turbine = "1.1.0"
 zxing = "3.5.3"
+testng = "6.9.6"
 
 [libraries]
 # Format: <maintainer>-<artifact-name>
@@ -121,6 +122,7 @@ square-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", v
 square-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 square-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 zxing-zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
+testng = { group = "org.testng", name = "testng", version.ref = "testng" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-65

Closes #167 

## 📔 Objective

Adds a new comparator to sort items alphabetically, giving precedence to special characters over letters and digits.
This comparator is used to sort items in the item search screen and the main item listing screen.

The comparator also gives priority to lowercase letters when comparing equal letters (e.g., 'a' comes before 'A').

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="372" alt="image" src="https://github.com/user-attachments/assets/17ff289a-9d90-452e-aace-c369af9c3a83"> | <img width="371" alt="image" src="https://github.com/user-attachments/assets/35ee1347-b329-4778-93d5-1bae13f49ab3"> | 
| <img width="372" alt="image" src="https://github.com/user-attachments/assets/aec28b3c-29b7-4080-8f79-c0a97e9374e0"> | <img width="376" alt="image" src="https://github.com/user-attachments/assets/07a65aa7-adda-48f6-8d3b-44585970d72a"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
