### PR TITLE
[BWA-90] Remove WorkManager for clipboard clearing

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -8,13 +8,9 @@ import android.widget.Toast
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.getSystemService
 import androidx.core.os.persistableBundleOf
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.base.util.Text
 import com.bitwarden.authenticator.ui.platform.base.util.toAnnotatedString
-import com.bitwarden.data.platform.manager.clipboard.ClearClipboardWorker
 
 /**
  * Default implementation of the [BitwardenClipboardManager] interface.
@@ -48,17 +44,6 @@ class BitwardenClipboardManagerImpl(
                 )
                 .show()
         }
-
-        val clearClipboardRequest: OneTimeWorkRequest =
-            OneTimeWorkRequest
-                .Builder(ClearClipboardWorker::class.java)
-                .build()
-
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            "ClearClipboard",
-            ExistingWorkPolicy.REPLACE,
-            clearClipboardRequest,
-        )
     }
 
     override fun setText(text: String, isSensitive: Boolean, toastDescriptorOverride: String?) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-90
Closes #191 

## 📔 Objective

This commit removes the use of WorkManager for clearing the clipboard and instead relies on the system's default clipboard timeout.

## 📸 Screenshots

<img width="531" alt="image" src="https://github.com/user-attachments/assets/f6ce799d-1f90-4a13-8015-256064c33fe1">

<img width="148" alt="image" src="https://github.com/user-attachments/assets/193a5233-f737-410b-b7f1-a7d1e35728fe">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
