### PR TITLE
BITAU-68 Specify build specific bridge permission in manifest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,12 +54,14 @@ android {
 
     buildTypes {
         debug {
+            manifestPlaceholders["targetBitwardenAppId"] = "com.x8bit.bitwarden.dev"
             signingConfig = signingConfigs.getByName("debug")
             isDebuggable = true
             isMinifyEnabled = false
         }
 
         release {
+            manifestPlaceholders["targetBitwardenAppId"] = "com.x8bit.bitwarden"
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <uses-permission android:name="com.x8bit.bitwarden.permission.AUTHENTICATOR_BRIDGE_SERVICE" />
+    <uses-permission android:name="${targetBitwardenAppId}.permission.AUTHENTICATOR_BRIDGE_SERVICE" />
 
     <application
         android:name=".AuthenticatorApplication"


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-68

## 📔 Objective

We need to specify specific permission per build type. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
