### PR TITLE
[BWA-10] Handle exception when checking for suspicious intents

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/IntentExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/util/IntentExtensions.kt
@@ -7,7 +7,13 @@ import android.content.Intent
  */
 val Intent.isSuspicious: Boolean
     get() {
-        val containsSuspiciousExtras = extras?.isEmpty?.not() ?: false
-        val containsSuspiciousData = data != null
-        return containsSuspiciousData || containsSuspiciousExtras
+        return try {
+            val containsSuspiciousExtras = extras?.isEmpty() == false
+            val containsSuspiciousData = data != null
+            containsSuspiciousData || containsSuspiciousExtras
+        } catch (_: Exception) {
+            // `unparcel()` throws an exception on Android 12 and below if the bundle contains
+            // suspicious data, so we catch the exception and return true.
+            true
+        }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-10

## 📔 Objective

The commit adds a try-catch block to the `isSuspicious` extension function for `Intent`. This
handles potential exceptions that could occur when accessing the intent's extras in Android 12 or below, and marks the intent as suspicious if an exception is thrown. This change improves the security of the app by preventing unexpected crashes and ensuring that potentially malicious intents are flagged appropriately.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
