### PR TITLE
Fix empty state for totp codes

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/manager/TotpCodeManagerImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.isActive
 import java.time.Clock
 import java.util.UUID
@@ -28,6 +29,9 @@ class TotpCodeManagerImpl @Inject constructor(
     override fun getTotpCodesFlow(
         itemList: List<AuthenticatorItem>,
     ): Flow<List<VerificationCodeItem>> {
+        if (itemList.isEmpty()) {
+            return flowOf(emptyList())
+        }
         val flows = itemList.map { it.toFlowOfVerificationCodes() }
         return combine(flows) { it.toList() }
     }

--- a/app/src/test/java/com/bitwarden/authenticator/data/authenticator/manager/util/TotpCodeManagerTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/authenticator/manager/util/TotpCodeManagerTest.kt
@@ -1,0 +1,36 @@
+package com.bitwarden.authenticator.data.authenticator.manager.util
+
+import app.cash.turbine.test
+import com.bitwarden.authenticator.data.authenticator.datasource.sdk.AuthenticatorSdkSource
+import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManagerImpl
+import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class TotpCodeManagerTest {
+
+    private val clock: Clock = Clock.fixed(
+        Instant.parse("2023-10-27T12:00:00Z"),
+        ZoneOffset.UTC,
+    )
+    private val authenticatorSdkSource: AuthenticatorSdkSource = mockk()
+
+    private val manager = TotpCodeManagerImpl(
+        authenticatorSdkSource = authenticatorSdkSource,
+        clock = clock,
+    )
+
+    @Test
+    fun `getTotpCodesFlow should return flow that emits empty list when input list is empty`() =
+        runTest {
+            manager.getTotpCodesFlow(emptyList()).test {
+                assertEquals(emptyList<VerificationCodeItem>(), awaitItem())
+                awaitComplete()
+            }
+        }
+}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Fix a bug I noticed when moving to the empty state for TOTP items.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
