### PR TITLE
Return noop bridge manager when password sync feature flag is off

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
@@ -3,8 +3,11 @@ package com.bitwarden.authenticator.data.authenticator.repository.di
 import android.content.Context
 import com.bitwarden.authenticator.data.auth.datasource.disk.AuthDiskSource
 import com.bitwarden.authenticator.data.authenticator.repository.util.SymmetricKeyStorageProviderImpl
+import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
+import com.bitwarden.authenticator.data.platform.manager.model.LocalFeatureFlag
 import com.bitwarden.authenticatorbridge.factory.AuthenticatorBridgeFactory
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
+import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import com.bitwarden.authenticatorbridge.manager.model.AuthenticatorBridgeConnectionType
 import com.bitwarden.authenticatorbridge.provider.SymmetricKeyStorageProvider
 import dagger.Module
@@ -12,6 +15,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Singleton
 
 /**
@@ -33,10 +38,21 @@ object AuthenticatorBridgeModule {
     fun provideAuthenticatorBridgeManager(
         factory: AuthenticatorBridgeFactory,
         symmetricKeyStorageProvider: SymmetricKeyStorageProvider,
-    ): AuthenticatorBridgeManager = factory.getAuthenticatorBridgeManager(
-        connectionType = AuthenticatorBridgeConnectionType.DEV,
-        symmetricKeyStorageProvider = symmetricKeyStorageProvider,
-    )
+        featureFlagManager: FeatureFlagManager,
+    ): AuthenticatorBridgeManager =
+        if (featureFlagManager.getFeatureFlag(LocalFeatureFlag.PasswordManagerSync)) {
+            factory.getAuthenticatorBridgeManager(
+                connectionType = AuthenticatorBridgeConnectionType.DEV,
+                symmetricKeyStorageProvider = symmetricKeyStorageProvider,
+            )
+        } else {
+            // If feature flag is not enabled, return noop bridge manager so we never
+            // connect to bridge service:
+            object : AuthenticatorBridgeManager {
+                override val accountSyncStateFlow: StateFlow<AccountSyncState>
+                    get() = MutableStateFlow(AccountSyncState.Loading)
+            }
+        }
 
     @Provides
     fun providesSymmetricKeyStorageProvider(

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
@@ -46,7 +46,7 @@ object AuthenticatorBridgeModule {
                 symmetricKeyStorageProvider = symmetricKeyStorageProvider,
             )
         } else {
-            // If feature flag is not enabled, return noop bridge manager so we never
+            // If feature flag is not enabled, return no-op bridge manager so we never
             // connect to bridge service:
             object : AuthenticatorBridgeManager {
                 override val accountSyncStateFlow: StateFlow<AccountSyncState>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

I realized that `AuthenticatorBridgeManagerImpl` connects to bridge service and subscribes to lifecycle events in `init`, so I wanted to make sure we aren't instantiating one of those when the feature flag is off. 

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
