### PR TITLE
BITAU-90 Add "Sync with Bitwarden App" row to settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,12 @@ android {
     lint {
         disable.add("MissingTranslation")
     }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        // Required for Robolectric
+        unitTests.isIncludeAndroidResources = true
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 kotlin {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.bitwarden.authenticator.ui.platform.feature.settings
 
+import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -102,6 +103,24 @@ fun SettingsScreen(
             SettingsEvent.NavigateToPrivacyPolicy -> {
                 intentManager.launchUri("https://bitwarden.com/privacy".toUri())
             }
+
+            SettingsEvent.NavigateToBitwardenApp -> {
+
+                intentManager.startActivity(
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        "bitwarden://settings/account_security".toUri(),
+                    ).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    },
+                )
+            }
+
+            SettingsEvent.NavigateToBitwardenPlayStoreListing -> {
+                intentManager.launchUri(
+                    "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden".toUri(),
+                )
+            }
         }
     }
 
@@ -150,6 +169,12 @@ fun SettingsScreen(
                         viewModel.trySendAction(SettingsAction.DataClick.BackupClick)
                     }
                 },
+                onSyncWithBitwardenClick = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
+                    }
+                },
+                shouldShowSyncWithBitwardenApp = state.showSyncWithBitwarden,
             )
             Spacer(modifier = Modifier.height(16.dp))
             AppearanceSettings(
@@ -237,11 +262,14 @@ private fun SecuritySettings(
 //region Data settings
 
 @Composable
+@Suppress("LongMethod")
 private fun VaultSettings(
     modifier: Modifier = Modifier,
     onExportClick: () -> Unit,
     onImportClick: () -> Unit,
     onBackupClick: () -> Unit,
+    onSyncWithBitwardenClick: () -> Unit,
+    shouldShowSyncWithBitwardenApp: Boolean,
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
@@ -294,6 +322,25 @@ private fun VaultSettings(
         dialogConfirmButtonText = stringResource(R.string.learn_more),
         dialogDismissButtonText = stringResource(R.string.ok),
     )
+    if (shouldShowSyncWithBitwardenApp) {
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenTextRow(
+            text = stringResource(id = R.string.sync_with_bitwarden_app),
+            onClick = onSyncWithBitwardenClick,
+            modifier = modifier,
+            withDivider = true,
+            content = {
+                Icon(
+                    modifier = Modifier
+                        .mirrorIfRtl()
+                        .size(24.dp),
+                    painter = painterResource(id = R.drawable.ic_external_link),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            },
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,5 @@
     <string name="download_bitwarden_card_title">Download the Bitwarden app</string>
     <string name="download_bitwarden_card_message">Store all of your logins and sync verification codes directly with the Authenticator app.</string>
     <string name="download">Download</string>
+    <string name="sync_with_bitwarden_app">Sync with Bitwarden app</string>
 </resources>

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/base/BaseComposeTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/base/BaseComposeTest.kt
@@ -1,0 +1,59 @@
+package com.bitwarden.authenticator.ui.platform.base
+
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
+import org.junit.Rule
+
+/**
+ * A base class that can be used for performing Compose-layer testing using Robolectric, Compose
+ * Testing, and JUnit 4.
+ */
+abstract class BaseComposeTest : BaseRobolectricTest() {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * instance of [OnBackPressedDispatcher] made available if testing using
+     *
+     * [setContentWithBackDispatcher] or [runTestWithTheme]
+     */
+    var backDispatcher: OnBackPressedDispatcher? = null
+        private set
+
+    /**
+     * Helper for testing a basic Composable function that only requires a Composable environment
+     * with the [BitwardenTheme].
+     */
+    protected fun runTestWithTheme(
+        theme: AppTheme,
+        test: @Composable () -> Unit,
+    ) {
+        composeTestRule.setContent {
+            AuthenticatorTheme(
+                theme = theme,
+            ) {
+                backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+                test()
+            }
+        }
+    }
+
+    /**
+     * Helper for testing a basic Composable function that provides access to a
+     * [OnBackPressedDispatcher].
+     *
+     * Use if the [Composable] function being tested uses a [BackHandler]
+     */
+    protected fun setContentWithBackDispatcher(test: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+            test()
+        }
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/base/BaseRobolectricTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/base/BaseRobolectricTest.kt
@@ -1,0 +1,21 @@
+package com.bitwarden.authenticator.ui.platform.base
+
+import dagger.hilt.android.testing.HiltTestApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+
+/**
+ * A base class that can be used for performing tests that use Robolectric and JUnit 4.
+ */
+@Config(
+    application = HiltTestApplication::class,
+    sdk = [Config.NEWEST_SDK],
+)
+@RunWith(RobolectricTestRunner::class)
+abstract class BaseRobolectricTest {
+    init {
+        ShadowLog.stream = System.out
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -1,0 +1,128 @@
+package com.bitwarden.authenticator.ui.platform.feature.settings
+
+import android.content.Intent
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.core.net.toUri
+import com.bitwarden.authenticator.BuildConfig
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.data.platform.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.authenticator.ui.platform.base.BaseComposeTest
+import com.bitwarden.authenticator.ui.platform.base.util.asText
+import com.bitwarden.authenticator.ui.platform.base.util.concat
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
+import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Test
+import org.junit.Before
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+
+class SettingsScreenTest : BaseComposeTest() {
+
+    private var onNavigateToTutorialCalled = false
+    private var onNaviateToExportCalled = false
+    private var onNavigateToImportCalled = false
+
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
+    private val mutableEventFlow = bufferedMutableSharedFlow<SettingsEvent>()
+
+    val viewModel: SettingsViewModel = mockk {
+        every { stateFlow } returns mutableStateFlow
+        every { eventFlow } returns mutableEventFlow
+        every { trySendAction(any()) } just runs
+    }
+
+    private val biometricsManager: BiometricsManager = mockk {
+        every { isBiometricsSupported } returns true
+    }
+    private val intentManager: IntentManager = mockk()
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            SettingsScreen(
+                viewModel = viewModel,
+                biometricsManager = biometricsManager,
+                intentManager = intentManager,
+                onNavigateToTutorial = { onNavigateToTutorialCalled = true },
+                onNavigateToExport = { onNaviateToExportCalled = true },
+                onNavigateToImport = { onNavigateToImportCalled = true },
+            )
+        }
+    }
+
+    @Test
+    fun `Sync with Bitwarden row should be hidden when showSyncWithBitwarden is false`() {
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            showSyncWithBitwarden = false,
+        )
+        composeTestRule.onNodeWithText("Sync with Bitwarden app").assertDoesNotExist()
+    }
+
+    @Test
+    fun `Sync with Bitwarden row click should send SyncWithBitwardenClick action`() {
+        composeTestRule
+            .onNodeWithText("Sync with Bitwarden app")
+            .performScrollTo()
+            .performClick()
+        verify { viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick) }
+    }
+
+    @Test
+    fun `on NavigateToBitwardenApp receive should launch bitwarden account security deep link`() {
+        every { intentManager.startActivity(any()) } just runs
+        val intentSlot = slot<Intent>()
+        val expectedIntent = Intent(
+            Intent.ACTION_VIEW,
+            "bitwarden://settings/account_security".toUri(),
+        ).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        mutableEventFlow.tryEmit(SettingsEvent.NavigateToBitwardenApp)
+        verify { intentManager.startActivity(capture(intentSlot)) }
+        assertEquals(
+            expectedIntent.data,
+            intentSlot.captured.data,
+        )
+        assertEquals(
+            expectedIntent.flags,
+            intentSlot.captured.flags,
+        )
+    }
+
+    @Test
+    fun `on NavigateToBitwardenPlayStoreListing receive launch Bitwarden Play Store URI`() {
+        every { intentManager.launchUri(any()) } just runs
+        mutableEventFlow.tryEmit(SettingsEvent.NavigateToBitwardenPlayStoreListing)
+        verify {
+            intentManager.launchUri(
+                "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden".toUri(),
+            )
+        }
+    }
+}
+
+private val APP_LANGUAGE = AppLanguage.ENGLISH
+private val APP_THEME = AppTheme.DEFAULT
+private val DEFAULT_STATE = SettingsState(
+    appearance = SettingsState.Appearance(
+        APP_LANGUAGE,
+        APP_THEME,
+    ),
+    isSubmitCrashLogsEnabled = true,
+    isUnlockWithBiometricsEnabled = true,
+    showSyncWithBitwarden = true,
+    dialog = null,
+    version = R.string.version.asText()
+        .concat(": ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText()),
+    copyrightInfo = "© Bitwarden Inc. 2015-2024".asText(),
+)

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -1,0 +1,156 @@
+package com.bitwarden.authenticator.ui.platform.feature.settings
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.bitwarden.authenticator.BuildConfig
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
+import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.bitwarden.authenticator.data.platform.manager.model.LocalFeatureFlag
+import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
+import com.bitwarden.authenticator.ui.platform.base.BaseViewModelTest
+import com.bitwarden.authenticator.ui.platform.base.util.asText
+import com.bitwarden.authenticator.ui.platform.base.util.concat
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
+import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class SettingsViewModelTest : BaseViewModelTest() {
+
+    private val authenticatorBridgeManager: AuthenticatorBridgeManager = mockk {
+        every { accountSyncStateFlow } returns MutableStateFlow(AccountSyncState.Loading)
+    }
+    private val settingsRepository: SettingsRepository = mockk {
+        every { appLanguage } returns APP_LANGUAGE
+        every { appTheme } returns APP_THEME
+        every { isUnlockWithBiometricsEnabled } returns true
+        every { isCrashLoggingEnabled } returns true
+    }
+    private val clipboardManager: BitwardenClipboardManager = mockk()
+    private val featureFlagManager: FeatureFlagManager = mockk {
+        every { getFeatureFlag(LocalFeatureFlag.PasswordManagerSync) } returns true
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `initialState should be correct when saved state is null and password manager feature flag is off`() {
+        every {
+            featureFlagManager.getFeatureFlag(LocalFeatureFlag.PasswordManagerSync)
+        } returns false
+        val viewModel = createViewModel(savedState = null)
+        val expectedState = DEFAULT_STATE.copy(
+            showSyncWithBitwarden = false,
+        )
+        assertEquals(
+            expectedState,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `initialState should be correct when saved state is null and password manager feature flag is on but OS version is too low`() {
+        every {
+            authenticatorBridgeManager.accountSyncStateFlow
+        } returns MutableStateFlow(AccountSyncState.OsVersionNotSupported)
+        val viewModel = createViewModel(savedState = null)
+        val expectedState = DEFAULT_STATE.copy(
+            showSyncWithBitwarden = false,
+        )
+        assertEquals(
+            expectedState,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `initialState should be correct when saved state is null and password manager feature flag is on and OS version is supported`() {
+        every {
+            authenticatorBridgeManager.accountSyncStateFlow
+        } returns MutableStateFlow(AccountSyncState.Loading)
+        every {
+            featureFlagManager.getFeatureFlag(LocalFeatureFlag.PasswordManagerSync)
+        } returns true
+        val viewModel = createViewModel(savedState = null)
+        val expectedState = DEFAULT_STATE.copy(
+            showSyncWithBitwarden = true,
+        )
+        assertEquals(
+            expectedState,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `on SyncWithBitwardenClick receive with AccountSyncState AppNotInstalled should emit NavigateToBitwardenPlayStoreListing`() =
+        runTest {
+            every {
+                authenticatorBridgeManager.accountSyncStateFlow
+            } returns MutableStateFlow(AccountSyncState.AppNotInstalled)
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
+                assertEquals(
+                    SettingsEvent.NavigateToBitwardenPlayStoreListing,
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `on SyncWithBitwardenClick receive with AccountSyncState not AppNotInstalled should emit NavigateToBitwardenApp`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
+                assertEquals(
+                    SettingsEvent.NavigateToBitwardenApp,
+                    awaitItem(),
+                )
+            }
+        }
+
+    private fun createViewModel(
+        savedState: SettingsState? = DEFAULT_STATE,
+    ) = SettingsViewModel(
+        savedStateHandle = SavedStateHandle().apply { this["state"] = savedState },
+        clock = CLOCK,
+        authenticatorBridgeManager = authenticatorBridgeManager,
+        settingsRepository = settingsRepository,
+        clipboardManager = clipboardManager,
+        featureFlagManager = featureFlagManager,
+    )
+}
+
+private val APP_LANGUAGE = AppLanguage.ENGLISH
+private val APP_THEME = AppTheme.DEFAULT
+private val CLOCK = Clock.fixed(
+    Instant.parse("2024-10-12T12:00:00Z"),
+    ZoneOffset.UTC,
+)
+private val DEFAULT_STATE = SettingsState(
+    appearance = SettingsState.Appearance(
+        APP_LANGUAGE,
+        APP_THEME,
+    ),
+    isSubmitCrashLogsEnabled = true,
+    isUnlockWithBiometricsEnabled = true,
+    showSyncWithBitwarden = true,
+    dialog = null,
+    version = R.string.version.asText()
+        .concat(": ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText()),
+    copyrightInfo = "© Bitwarden Inc. 2015-2024".asText(),
+)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :android do
 
   desc "Runs tests"
   lane :check do
-    gradle(tasks: ["check","koverXmlReportDebug"])
+    gradle(tasks: ["testDebug", "lintDebug", "detekt","koverXmlReportDebug"])
   end
 
   desc "Apply build version information"


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-90

## 📔 Objective

The goal of this PR is to add a row to that takes the user to the Bitwarden account security screen so that they can turn on account syncing. If the user doesn't have Bitwarden installed, it should take them to the play store listing. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/1c86bc2c-16f3-4cc1-89ac-4cecadf88400" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
