### PR TITLE
Only run debug test variant on CI 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :android do
 
   desc "Runs tests"
   lane :check do
-    gradle(tasks: ["check","koverXmlReportDebug"])
+    gradle(tasks: ["testDebug", "lintDebug", "detekt","koverXmlReportDebug"])
   end
 
   desc "Apply build version information"


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

I added first UI tests in a [different PR,](https://github.com/bitwarden/authenticator-android/pull/239) and found that we cannot run release variant UI tests on CI. This matches [what we have in the main password manager app.](https://github.com/bitwarden/android/blob/main/fastlane/Fastfile#L108-L113).

I figured a change this specific deserves its own PR!

## 📸 Screenshots

N/A 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
