### PR TITLE
Remove Firebase APK distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
         description: "Optional. Build number to use. Overrides default of GitHub run number."
         required: false
         type: number
+      distribute-to-firebase:
+        description: "Optional. Distribute artifacts to Firebase."
+        required: false
+        default: false
+        type: boolean
       publish-to-play-store:
         description: "Optional. Deploy bundle artifact to Google Play Store"
         required: false
@@ -120,6 +125,7 @@ jobs:
           --name authenticator_aab-keystore.jks --file ${{ github.workspace }}/keystores/authenticator_aab-keystore.jks --output none
 
       - name: Download Firebase credentials
+        if : ${{ inputs.distribute-to-firebase }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -230,19 +236,11 @@ jobs:
           if-no-files-found: error
 
       - name: Install Firebase app distribution plugin
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ inputs.distribute-to-firebase }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
-      - name: Publish release artifacts to Firebase
-        if: ${{ github.ref_name == 'main' && matrix.variant == 'apk' }}
-        env:
-          FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
-        run: |
-          bundle exec fastlane distributeReleaseToFirebase \
-          serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }}
-
       - name: Publish release bundle to Firebase
-        if: ${{ github.ref_name == 'main' && matrix.variant == 'aab' }}
+        if: ${{ matrix.variant == 'aab' && inputs.distribute-to-firebase }}
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           --name authenticator_aab-keystore.jks --file ${{ github.workspace }}/keystores/authenticator_aab-keystore.jks --output none
 
       - name: Download Firebase credentials
-        if : ${{ inputs.distribute-to-firebase }}
+        if : ${{ inputs.distribute-to-firebase || github.event_name == 'push' }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -236,11 +236,11 @@ jobs:
           if-no-files-found: error
 
       - name: Install Firebase app distribution plugin
-        if: ${{ inputs.distribute-to-firebase }}
+        if: ${{ inputs.distribute-to-firebase || github.event_name == 'push' }}
         run: bundle exec fastlane add_plugin firebase_app_distribution
 
       - name: Publish release bundle to Firebase
-        if: ${{ matrix.variant == 'aab' && inputs.distribute-to-firebase }}
+        if: ${{ matrix.variant == 'aab' && (inputs.distribute-to-firebase || github.event_name == 'push' }}
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version-name:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,8 +94,8 @@ platform :android do
     )
   end
 
-  desc "Publish release to Firebase"
-  lane :distributeReleaseToFirebase do |options|
+  desc "Publish release AAB to Firebase"
+  lane :distributeReleaseBundleToFirebase do |options|
     release_notes = changelog_from_git_commits(
       commits_count: 1,
       pretty: "- %s"
@@ -105,32 +105,13 @@ platform :android do
 
     firebase_app_distribution(
       app: "1:867301491091:android:50b626dba42a361651e866",
-      android_artifact_type: "APK",
-      android_artifact_path: "app/build/outputs/apk/release/com.bitwarden.authenticator-release.apk",
+      android_artifact_type: "AAB",
+      android_artifact_path: "app/build/outputs/bundle/release/com.bitwarden.authenticator-release.aab",
       service_credentials_file: options[:serviceCredentialsFile],
       groups: "internal-prod-group",
       release_notes: release_notes,
     )
   end
-
-    desc "Publish release AAB to Firebase"
-    lane :distributeReleaseBundleToFirebase do |options|
-      release_notes = changelog_from_git_commits(
-        commits_count: 1,
-        pretty: "- %s"
-      )
-
-      puts "Release notes #{release_notes}"
-
-      firebase_app_distribution(
-        app: "1:867301491091:android:50b626dba42a361651e866",
-        android_artifact_type: "AAB",
-        android_artifact_path: "app/build/outputs/bundle/release/com.bitwarden.authenticator-release.aab",
-        service_credentials_file: options[:serviceCredentialsFile],
-        groups: "internal-prod-group",
-        release_notes: release_notes,
-      )
-    end
 
   desc "Publish release to Google Play Store"
   lane :publishReleaseToGooglePlayStore do |options|


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

We don't need to distribute APKs to firebase, just AAB distribution will suffice. This PR also updates the build workflow to mirror the main app workflow: we only distribute to Firebase when the optional variable is true.

The main difference between the Authenticator setup and the main app setup is the main app distributes to firebase on every merge to main, whereas the Authenticator app still requires a manual action to be run to distribute to firebase.

## 📸 Screenshots

I've confirmed this workflow properly only uploads AAB files to firebase, no more APKs:
<img width="1064" alt="Screenshot 2024-10-17 at 11 48 46 AM" src="https://github.com/user-attachments/assets/bfd3d1da-12c3-4e48-9b08-6362e2ef566b">



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
