### PR TITLE
Mark IntentManagerImpl as not covered by code coverage

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -15,11 +15,13 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
 import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.data.platform.annotation.OmitFromCoverage
 
 /**
  * The default implementation of the [IntentManager] for simplifying the handling of Android
  * Intents within a given context.
  */
+@OmitFromCoverage
 class IntentManagerImpl(
     private val context: Context,
 ) : IntentManager {


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

The `IntentManagerImpl` class is now marked with the `@OmitFromCoverage` annotation, excluding it from code coverage reports.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
