### PR TITLE
BITAU-181 Allow user to update default save options from settings

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -2,6 +2,7 @@ package com.bitwarden.authenticator.data.platform.datasource.disk
 
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -23,6 +24,11 @@ interface SettingsDiskSource {
      * Emits updates that track [appTheme].
      */
     val appThemeFlow: Flow<AppTheme>
+
+    /**
+     * The currently persisted default save option.
+     */
+    var defaultSaveOption: DefaultSaveOption
 
     /**
      * The currently persisted biometric integrity source for the system.

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -5,11 +5,13 @@ import com.bitwarden.authenticator.data.platform.datasource.disk.BaseDiskSource.
 import com.bitwarden.authenticator.data.platform.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onSubscription
 
 private const val APP_THEME_KEY = "$BASE_KEY:theme"
 private const val APP_LANGUAGE_KEY = "$BASE_KEY:appLocale"
+private const val DEFAULT_SAVE_OPTION_KEY = "$BASE_KEY:defaultSaveOption"
 private const val SYSTEM_BIOMETRIC_INTEGRITY_SOURCE_KEY = "$BASE_KEY:biometricIntegritySource"
 private const val ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY = "$BASE_KEY:accountBiometricIntegrityValid"
 private const val ALERT_THRESHOLD_SECONDS_KEY = "$BASE_KEY:alertThresholdSeconds"
@@ -73,6 +75,19 @@ class SettingsDiskSourceImpl(
     override val appThemeFlow: Flow<AppTheme>
         get() = mutableAppThemeFlow
             .onSubscription { emit(appTheme) }
+
+    override var defaultSaveOption: DefaultSaveOption
+        get() = getString(key = DEFAULT_SAVE_OPTION_KEY)
+            ?.let { storedValue ->
+                DefaultSaveOption.entries.firstOrNull { storedValue == it.value }
+            }
+            ?: DefaultSaveOption.NONE
+        set(newValue) {
+            putString(
+                key = DEFAULT_SAVE_OPTION_KEY,
+                value = newValue.value,
+            )
+        }
 
     override var systemBiometricIntegritySource: String?
         get() = getString(key = SYSTEM_BIOMETRIC_INTEGRITY_SOURCE_KEY)

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
@@ -3,6 +3,7 @@ package com.bitwarden.authenticator.data.platform.repository
 import com.bitwarden.authenticator.data.platform.repository.model.BiometricsKeyResult
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -30,6 +31,11 @@ interface SettingsRepository {
      * The currently stored expiration alert threshold.
      */
     var authenticatorAlertThresholdSeconds: Int
+
+    /**
+     * The currently stored [DefaultSaveOption].
+     */
+    var defaultSaveOption: DefaultSaveOption
 
     /**
      * Whether or not biometric unlocking is enabled for the current user.

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.bitwarden.authenticator.data.platform.manager.DispatcherManager
 import com.bitwarden.authenticator.data.platform.repository.model.BiometricsKeyResult
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -40,6 +41,8 @@ class SettingsRepositoryImpl(
     override var appTheme: AppTheme by settingsDiskSource::appTheme
 
     override var authenticatorAlertThresholdSeconds = settingsDiskSource.getAlertThresholdSeconds()
+
+    override var defaultSaveOption: DefaultSaveOption by settingsDiskSource::defaultSaveOption
 
     override val isUnlockWithBiometricsEnabled: Boolean
         get() = authDiskSource.getUserBiometricUnlockKey() != null

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.base.util.Text
 import com.bitwarden.authenticator.ui.platform.components.button.BitwardenTextButton
 import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 
@@ -31,7 +32,11 @@ import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
  * Displays a dialog with a title and "Cancel" button.
  *
  * @param title Title to display.
+ * @param subTitle Optional subtitle to display below the title.
+ * @param dismissLabel Label to show on the dismiss button at the bottom of the dialog.
  * @param onDismissRequest Invoked when the user dismisses the dialog.
+ * @param onDismissActionClick Invoked when the user dismisses the via the dismiss action button.
+ * By default, this just defers to onDismissRequest.
  * @param selectionItems Lambda containing selection items to show to the user. See
  * [BitwardenSelectionRow].
  */
@@ -40,7 +45,10 @@ import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 @Composable
 fun BitwardenSelectionDialog(
     title: String,
+    subTitle: String? = null,
+    dismissLabel: String = stringResource(R.string.cancel),
     onDismissRequest: () -> Unit,
+    onDismissActionClick: () -> Unit = onDismissRequest,
     selectionItems: @Composable ColumnScope.() -> Unit = {},
 ) {
     Dialog(
@@ -69,6 +77,20 @@ fun BitwardenSelectionDialog(
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.headlineSmall,
             )
+            subTitle?.let {
+                Text(
+                    modifier = Modifier
+                        .padding(
+                            start = 24.dp,
+                            end = 24.dp,
+                            bottom = 24.dp,
+                        )
+                        .fillMaxWidth(),
+                    text = subTitle,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
             if (scrollState.canScrollBackward) {
                 Box(
                     modifier = Modifier
@@ -93,8 +115,8 @@ fun BitwardenSelectionDialog(
             }
             BitwardenTextButton(
                 modifier = Modifier.padding(24.dp),
-                label = stringResource(id = R.string.cancel),
-                onClick = onDismissRequest,
+                label = dismissLabel,
+                onClick = onDismissActionClick,
             )
         }
     }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.bitwarden.authenticator.R
-import com.bitwarden.authenticator.ui.platform.base.util.Text
 import com.bitwarden.authenticator.ui.platform.components.button.BitwardenTextButton
 import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 
@@ -32,7 +31,7 @@ import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
  * Displays a dialog with a title and "Cancel" button.
  *
  * @param title Title to display.
- * @param subTitle Optional subtitle to display below the title.
+ * @param subtitle Optional subtitle to display below the title.
  * @param dismissLabel Label to show on the dismiss button at the bottom of the dialog.
  * @param onDismissRequest Invoked when the user dismisses the dialog.
  * @param onDismissActionClick Invoked when the user dismisses the via the dismiss action button.
@@ -45,7 +44,7 @@ import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 @Composable
 fun BitwardenSelectionDialog(
     title: String,
-    subTitle: String? = null,
+    subtitle: String? = null,
     dismissLabel: String = stringResource(R.string.cancel),
     onDismissRequest: () -> Unit,
     onDismissActionClick: () -> Unit = onDismissRequest,
@@ -77,7 +76,7 @@ fun BitwardenSelectionDialog(
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.headlineSmall,
             )
-            subTitle?.let {
+            subtitle?.let {
                 Text(
                     modifier = Modifier
                         .padding(
@@ -86,7 +85,7 @@ fun BitwardenSelectionDialog(
                             bottom = 24.dp,
                         )
                         .fillMaxWidth(),
-                    text = subTitle,
+                    text = subtitle,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodyMedium,
                 )

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.bitwarden.authenticator.ui.platform.feature.settings
 
 import android.content.Intent
@@ -60,6 +62,7 @@ import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaf
 import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenWideSwitch
 import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
@@ -174,6 +177,15 @@ fun SettingsScreen(
                         viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
                     }
                 },
+                onDefaultSaveOptionUpdated = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(
+                            SettingsAction.DataClick.DefaultSaveOptionUpdated(it),
+                        )
+                    }
+                },
+                defaultSaveOption = state.defaultSaveOption,
+                shouldShowDefaultSaveOptions = state.showDefaultSaveOptionRow,
                 shouldShowSyncWithBitwardenApp = state.showSyncWithBitwarden,
             )
             Spacer(modifier = Modifier.height(16.dp))
@@ -265,11 +277,14 @@ private fun SecuritySettings(
 @Suppress("LongMethod")
 private fun VaultSettings(
     modifier: Modifier = Modifier,
+    defaultSaveOption: DefaultSaveOption,
     onExportClick: () -> Unit,
     onImportClick: () -> Unit,
     onBackupClick: () -> Unit,
     onSyncWithBitwardenClick: () -> Unit,
+    onDefaultSaveOptionUpdated: (DefaultSaveOption) -> Unit,
     shouldShowSyncWithBitwardenApp: Boolean,
+    shouldShowDefaultSaveOptions: Boolean,
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
@@ -340,6 +355,58 @@ private fun VaultSettings(
                 )
             },
         )
+    }
+    if (shouldShowDefaultSaveOptions) {
+        DefaultSaveOptionSelectionRow(
+            currentSelection = defaultSaveOption,
+            onSaveOptionUpdated = onDefaultSaveOptionUpdated,
+        )
+    }
+}
+
+@Composable
+private fun DefaultSaveOptionSelectionRow(
+    currentSelection: DefaultSaveOption,
+    onSaveOptionUpdated: (DefaultSaveOption) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var shouldShowDefaultSaveOptionDialog by remember { mutableStateOf(false) }
+
+    BitwardenTextRow(
+        text = stringResource(id = R.string.default_save_options),
+        onClick = { shouldShowDefaultSaveOptionDialog = true },
+        modifier = modifier,
+        withDivider = true,
+    ) {
+        Text(
+            modifier = Modifier.padding(vertical = 20.dp),
+            text = currentSelection.displayLabel(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    var dialogSelection by remember { mutableStateOf(currentSelection) }
+    if (shouldShowDefaultSaveOptionDialog) {
+        BitwardenSelectionDialog(
+            title = stringResource(id = R.string.default_save_options),
+            subTitle = stringResource(id = R.string.default_save_options_subtitle),
+            dismissLabel = stringResource(id = R.string.confirm),
+            onDismissRequest = { shouldShowDefaultSaveOptionDialog = false },
+            onDismissActionClick = {
+                onSaveOptionUpdated(dialogSelection)
+                shouldShowDefaultSaveOptionDialog = false
+            },
+        ) {
+            DefaultSaveOption.entries.forEach { option ->
+                BitwardenSelectionRow(
+                    text = option.displayLabel,
+                    isSelected = option == dialogSelection,
+                    onClick = {
+                        dialogSelection = DefaultSaveOption.entries.first { it == option }
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -389,7 +389,7 @@ private fun DefaultSaveOptionSelectionRow(
     if (shouldShowDefaultSaveOptionDialog) {
         BitwardenSelectionDialog(
             title = stringResource(id = R.string.default_save_options),
-            subTitle = stringResource(id = R.string.default_save_options_subtitle),
+            subtitle = stringResource(id = R.string.default_save_options_subtitle),
             dismissLabel = stringResource(id = R.string.confirm),
             onDismissRequest = { shouldShowDefaultSaveOptionDialog = false },
             onDismissActionClick = {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/data/model/DefaultSaveOption.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/data/model/DefaultSaveOption.kt
@@ -1,0 +1,12 @@
+package com.bitwarden.authenticator.ui.platform.feature.settings.data.model
+
+/**
+ * Represents the default save location the user has set.
+ *
+ * The [value] is used for consistent storage purposes.
+ */
+enum class DefaultSaveOption(val value: String?) {
+    BITWARDEN_APP(value = "bitwarden"),
+    LOCAL(value = "local"),
+    NONE(value = null),
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensions.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensions.kt
@@ -1,0 +1,16 @@
+package com.bitwarden.authenticator.ui.platform.util
+
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.base.util.Text
+import com.bitwarden.authenticator.ui.platform.base.util.asText
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+
+/**
+ * Returns a human-readable display label for the given [DefaultSaveOption].
+ */
+val DefaultSaveOption.displayLabel: Text
+    get() = when (this) {
+        DefaultSaveOption.NONE -> R.string.none.asText()
+        DefaultSaveOption.LOCAL -> R.string.save_locally.asText()
+        DefaultSaveOption.BITWARDEN_APP -> R.string.save_to_bitwarden.asText()
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,4 +133,10 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="please_try_again">Please try again</string>
     <string name="move_to_bitwarden">Move to Bitwarden</string>
+    <string name="default_save_options">Default save options</string>
+    <string name="save_to_bitwarden">Save to Bitwarden</string>
+    <string name="save_locally">Save locally</string>
+    <string name="none">None</string>
+    <string name="default_save_options_subtitle">Select where you would like to save new verification codes.</string>
+    <string name="confirm">Confirm</string>
 </resources>

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/SettingDiskSourceTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/SettingDiskSourceTest.kt
@@ -2,6 +2,8 @@ package com.bitwarden.authenticator.data.platform.datasource.disk
 
 import androidx.core.content.edit
 import com.bitwarden.authenticator.data.platform.base.FakeSharedPreferences
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -49,5 +51,48 @@ class SettingDiskSourceTest {
             putBoolean(sharedPrefsKey, true)
         }
         assertTrue(settingDiskSource.hasUserDismissedSyncWithBitwardenCard!!)
+    }
+
+    @Test
+    fun `defaultSaveOption should read and write from shared preferences`() {
+        val sharedPrefsKey = "bwPreferencesStorage:defaultSaveOption"
+
+        // Verify initial value is null and disk source should default to NONE
+        assertNull(sharedPreferences.getString(sharedPrefsKey, null))
+        assertEquals(
+            DefaultSaveOption.NONE,
+            settingDiskSource.defaultSaveOption,
+        )
+
+        // Updating the shared preferences should update disk source
+        sharedPreferences.edit {
+            putString(
+                sharedPrefsKey,
+                DefaultSaveOption.BITWARDEN_APP.value,
+            )
+        }
+        assertEquals(
+            DefaultSaveOption.BITWARDEN_APP,
+            settingDiskSource.defaultSaveOption,
+        )
+
+        // Updating the disk source should update shared preferences
+        settingDiskSource.defaultSaveOption = DefaultSaveOption.LOCAL
+        assertEquals(
+            DefaultSaveOption.LOCAL.value,
+            sharedPreferences.getString(sharedPrefsKey, null),
+        )
+
+        // Incorrect value should default to DefaultSaveOption.NONE
+        sharedPreferences.edit {
+            putString(
+                sharedPrefsKey,
+                "invalid",
+            )
+        }
+        assertEquals(
+            DefaultSaveOption.NONE,
+            settingDiskSource.defaultSaveOption,
+        )
     }
 }

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryTest.kt
@@ -6,11 +6,13 @@ import com.bitwarden.authenticator.data.authenticator.datasource.sdk.Authenticat
 import com.bitwarden.authenticator.data.platform.base.FakeDispatcherManager
 import com.bitwarden.authenticator.data.platform.datasource.disk.SettingsDiskSource
 import com.bitwarden.authenticator.data.platform.manager.BiometricsEncryptionManager
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -73,5 +75,21 @@ class SettingsRepositoryTest {
         every { settingsDiskSource.hasUserDismissedSyncWithBitwardenCard = true } just runs
         settingsRepository.hasUserDismissedSyncWithBitwardenCard = true
         verify { settingsRepository.hasUserDismissedSyncWithBitwardenCard = true }
+    }
+
+    @Test
+    fun `defaultSaveOption should pull from and update SettingsDiskSource`() {
+        // Reading from repository should read from disk source:
+        every { settingsDiskSource.defaultSaveOption } returns DefaultSaveOption.NONE
+        assertEquals(
+            DefaultSaveOption.NONE,
+            settingsRepository.defaultSaveOption,
+        )
+        verify { settingsDiskSource.defaultSaveOption }
+
+        // Writing to repository should write to disk source:
+        every { settingsDiskSource.defaultSaveOption = DefaultSaveOption.BITWARDEN_APP } just runs
+        settingsRepository.defaultSaveOption = DefaultSaveOption.BITWARDEN_APP
+        verify { settingsDiskSource.defaultSaveOption = DefaultSaveOption.BITWARDEN_APP }
     }
 }

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensionsTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensionsTest.kt
@@ -1,0 +1,25 @@
+package com.bitwarden.authenticator.ui.platform.util
+
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.base.util.asText
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DefaultSaveOptionExtensionsTest {
+
+    @Test
+    fun `displayLabel should map to correct labels`() {
+        DefaultSaveOption.entries.forEach {
+            val expected = when (it) {
+                DefaultSaveOption.BITWARDEN_APP -> R.string.save_to_bitwarden.asText()
+                DefaultSaveOption.LOCAL -> R.string.save_locally.asText()
+                DefaultSaveOption.NONE -> R.string.none.asText()
+            }
+            assertEquals(
+                expected,
+                it.displayLabel,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-181

## 📔 Objective

The goal of this PR is to allow the user to update their default save option from the settings screen.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/34cf7800-53ce-4ebe-912e-cdb2661aa53a" width="300" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
