### PR TITLE
BITAU-84 Show Snackbar the first time a user syncs accounts

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
@@ -87,7 +87,7 @@ interface AuthenticatorRepository {
 
     /**
      * Flow that emits `Unit` each time an account is synced from the main Bitwarden app for
-     * the firs time.
+     * the first time.
      */
     val firstTimeAccountSyncFlow: Flow<Unit>
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
@@ -84,4 +84,10 @@ interface AuthenticatorRepository {
         format: ImportFileFormat,
         fileData: IntentManager.FileData,
     ): ImportDataResult
+
+    /**
+     * Flow that emits `Unit` each time an account is synced from the main Bitwarden app for
+     * the firs time.
+     */
+    val firstTimeAccountSyncFlow: Flow<Unit>
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorRepositoryModule.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorRepositoryModule.kt
@@ -8,6 +8,7 @@ import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRe
 import com.bitwarden.authenticator.data.platform.manager.DispatcherManager
 import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
+import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import dagger.Module
 import dagger.Provides
@@ -32,6 +33,7 @@ object AuthenticatorRepositoryModule {
         fileManager: FileManager,
         importManager: ImportManager,
         totpCodeManager: TotpCodeManager,
+        settingsRepository: SettingsRepository,
     ): AuthenticatorRepository = AuthenticatorRepositoryImpl(
         authenticatorBridgeManager = authenticatorBridgeManager,
         authenticatorDiskSource = authenticatorDiskSource,
@@ -40,5 +42,6 @@ object AuthenticatorRepositoryModule {
         fileManager = fileManager,
         importManager = importManager,
         totpCodeManager = totpCodeManager,
+        settingRepository = settingsRepository,
     )
 }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/BaseDiskSource.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/BaseDiskSource.kt
@@ -6,7 +6,7 @@ import androidx.core.content.edit
 /**
  * Base class for simplifying interactions with [SharedPreferences].
  */
-@Suppress("UnnecessaryAbstractClass")
+@Suppress("UnnecessaryAbstractClass", "TooManyFunctions")
 abstract class BaseDiskSource(
     private val sharedPreferences: SharedPreferences,
 ) {
@@ -120,6 +120,18 @@ abstract class BaseDiskSource(
             .filter { it.startsWith(prefix) }
             .forEach { sharedPreferences.edit { remove(it) } }
     }
+
+    protected fun putStringSet(
+        key: String,
+        value: Set<String>?,
+    ): Unit = sharedPreferences.edit {
+        putStringSet(key, value)
+    }
+
+    protected fun getStringSet(
+        key: String,
+        default: Set<String>?,
+    ): Set<String>? = sharedPreferences.getStringSet(key, default)
 
     @Suppress("UndocumentedPublicClass")
     companion object {

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -41,6 +41,11 @@ interface SettingsDiskSource {
     var hasSeenWelcomeTutorial: Boolean
 
     /**
+     * A set of Bitwarden account IDs that have previously been synced.
+     */
+    var previouslySyncedBitwardenAccountIds: Set<String>
+
+    /**
      * Emits update that track [hasSeenWelcomeTutorial]
      */
     val hasSeenWelcomeTutorialFlow: Flow<Boolean>

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -22,6 +22,8 @@ private const val HAS_USER_DISMISSED_DOWNLOAD_BITWARDEN_KEY =
     "$BASE_KEY:hasUserDismissedDownloadBitwardenCard"
 private const val HAS_USER_DISMISSED_SYNC_WITH_BITWARDEN_KEY =
     "$BASE_KEY:hasUserDismissedSyncWithBitwardenCard"
+private const val PREVIOUSLY_SYNCED_BITWARDEN_ACCOUNT_IDS_KEY =
+    "$BASE_KEY:previouslySyncedBitwardenAccountIds"
 private const val DEFAULT_ALERT_THRESHOLD_SECONDS = 7
 
 /**
@@ -100,6 +102,18 @@ class SettingsDiskSourceImpl(
         set(value) {
             putBoolean(key = FIRST_LAUNCH_KEY, value)
             mutableFirstLaunchFlow.tryEmit(hasSeenWelcomeTutorial)
+        }
+
+    override var previouslySyncedBitwardenAccountIds: Set<String>
+        get() = getStringSet(
+            key = PREVIOUSLY_SYNCED_BITWARDEN_ACCOUNT_IDS_KEY,
+            default = emptySet(),
+        ) ?: emptySet()
+        set(value) {
+            putStringSet(
+                key = PREVIOUSLY_SYNCED_BITWARDEN_ACCOUNT_IDS_KEY,
+                value = value,
+            )
         }
 
     override val hasSeenWelcomeTutorialFlow: Flow<Boolean>

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
@@ -63,6 +63,11 @@ interface SettingsRepository {
     var isScreenCaptureAllowed: Boolean
 
     /**
+     * A set of Bitwarden account IDs that have previously been synced.
+     */
+    var previouslySyncedBitwardenAccountIds: Set<String>
+
+    /**
      * Whether or not screen capture is allowed for the current user.
      */
     val isScreenCaptureAllowedStateFlow: StateFlow<Boolean>

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
@@ -89,6 +89,8 @@ class SettingsRepositoryImpl(
                 isScreenCaptureAllowed = value,
             )
         }
+    override var previouslySyncedBitwardenAccountIds: Set<String> by
+    settingsDiskSource::previouslySyncedBitwardenAccountIds
 
     override val isScreenCaptureAllowedStateFlow: StateFlow<Boolean>
         get() = settingsDiskSource.getScreenCaptureAllowedFlow()

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
@@ -1,0 +1,69 @@
+package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.bitwarden.authenticator.R
+
+/**
+ * Show a snackbar that says "Account synced from Bitwarden app" with a close action.
+ *
+ * @param state Snackbar state used to show/hide. The message and title from this state are unused.
+ */
+@Composable
+fun FirstTimeSyncSnackbarHost(
+    state: SnackbarHostState,
+) {
+    SnackbarHost(
+        hostState = state,
+        snackbar = {
+            Row(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .background(
+                        color = MaterialTheme.colorScheme.inverseSurface,
+                        shape = RoundedCornerShape(8.dp),
+                    )
+                    .shadow(elevation = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .weight(1f, fill = true),
+                    text = stringResource(R.string.account_synced_from_bitwarden_app),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+                IconButton(
+                    onClick = { state.currentSnackbarData?.dismiss() },
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close),
+                        contentDescription = stringResource(id = R.string.close),
+                        tint = MaterialTheme.colorScheme.inverseOnSurface,
+                        modifier = Modifier
+                            .size(24.dp),
+                    )
+                }
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -143,7 +143,7 @@ fun ItemListingScreen(
             }
 
             is ItemListingEvent.ShowFirstTimeSyncSnackbar -> {
-                // Message property is override by FirstTimeSyncSnackbarHost:
+                // Message property is overridden by FirstTimeSyncSnackbarHost:
                 snackbarHostState.showSnackbar("")
             }
         }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -105,6 +106,7 @@ fun ItemListingScreen(
             shouldShowPermissionDialog = true
         }
     }
+    val snackbarHostState = remember { SnackbarHostState() }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -138,6 +140,11 @@ fun ItemListingScreen(
 
             ItemListingEvent.NavigateToBitwardenSettings -> {
                 intentManager.startMainBitwardenAppAccountSettings()
+            }
+
+            is ItemListingEvent.ShowFirstTimeSyncSnackbar -> {
+                // Message property is override by FirstTimeSyncSnackbarHost:
+                snackbarHostState.showSnackbar("")
             }
         }
     }
@@ -177,8 +184,9 @@ fun ItemListingScreen(
     when (val currentState = state.viewState) {
         is ItemListingState.ViewState.Content -> {
             ItemListingContent(
-                currentState,
-                scrollBehavior,
+                state = currentState,
+                snackbarHostState = snackbarHostState,
+                scrollBehavior = scrollBehavior,
                 onNavigateToSearch = remember(viewModel) {
                     {
                         viewModel.trySendAction(
@@ -340,6 +348,7 @@ private fun ItemListingDialogs(
 @Composable
 private fun ItemListingContent(
     state: ItemListingState.ViewState.Content,
+    snackbarHostState: SnackbarHostState,
     scrollBehavior: TopAppBarScrollBehavior,
     onNavigateToSearch: () -> Unit,
     onScanQrCodeClick: () -> Unit,
@@ -406,6 +415,7 @@ private fun ItemListingContent(
             )
         },
         floatingActionButtonPosition = FabPosition.EndOverlay,
+        snackbarHost = { FirstTimeSyncSnackbarHost(state = snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -88,6 +88,12 @@ class ItemListingViewModel @Inject constructor(
             .map { ItemListingAction.Internal.TotpCodeReceive(totpResult = it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        authenticatorRepository
+            .firstTimeAccountSyncFlow
+            .map { ItemListingAction.Internal.FirstTimeUserSyncReceive }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: ItemListingAction) {
@@ -249,7 +255,15 @@ class ItemListingViewModel @Inject constructor(
             is ItemListingAction.Internal.AppThemeChangeReceive -> {
                 handleAppThemeChangeReceive(internalAction.appTheme)
             }
+
+            ItemListingAction.Internal.FirstTimeUserSyncReceive -> {
+                handleFirstTimeUserSync()
+            }
         }
+    }
+
+    private fun handleFirstTimeUserSync() {
+        sendEvent(ItemListingEvent.ShowFirstTimeSyncSnackbar)
     }
 
     private fun handleAppThemeChangeReceive(appTheme: AppTheme) {
@@ -790,6 +804,11 @@ sealed class ItemListingEvent {
     data class ShowToast(
         val message: Text,
     ) : ItemListingEvent()
+
+    /**
+     * Show a Snackbar letting the user know accounts have synced.
+     */
+    data object ShowFirstTimeSyncSnackbar : ItemListingEvent()
 }
 
 /**
@@ -902,6 +921,11 @@ sealed class ItemListingAction {
          * Indicates app theme change has been received.
          */
         data class AppThemeChangeReceive(val appTheme: AppTheme) : Internal()
+
+        /**
+         * Indicates that a user synced with Bitwarden for the first time.
+         */
+        data object FirstTimeUserSyncReceive : Internal()
     }
 
     /**

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,7 +30,7 @@
     <color name="on_surface_variant">@color/grey_45464F</color>
     <color name="outline">@color/grey_757780</color>
     <color name="outline_variant">@color/white_C5C6D0</color>
-    <color name="inverse_surface">@color/grey_303034</color>
+    <color name="inverse_surface">@color/blue_020F66</color>
     <color name="inverse_on_surface">@color/grey_F2F0F4</color>
     <color name="inverse_primary">@color/blue_B2C5FF</color>
     <color name="scrim">@color/black_000000</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,4 +144,5 @@
     <string name="verification_code_created">Verification code created</string>
     <string name="choose_save_location_message">Save this authenticator key here, or add it to a login in your Bitwarden app.</string>
     <string name="save_option_as_default">Save option as default</string>
+    <string name="account_synced_from_bitwarden_app">Account synced from Bitwarden app</string>
 </resources>

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/SettingDiskSourceTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/SettingDiskSourceTest.kt
@@ -95,4 +95,25 @@ class SettingDiskSourceTest {
             settingDiskSource.defaultSaveOption,
         )
     }
+
+    @Test
+    fun `previouslySyncedBitwardenAccountIds should read and write from shared preferences`() {
+        val sharedPrefsKey = "bwPreferencesStorage:previouslySyncedBitwardenAccountIds"
+
+        // Disk source should read value from shared preferences:
+        sharedPreferences.edit {
+            putStringSet(sharedPrefsKey, setOf("a"))
+        }
+        assertEquals(
+            setOf("a"),
+            settingDiskSource.previouslySyncedBitwardenAccountIds,
+        )
+
+        // Updating the disk source should update shared preferences:
+        settingDiskSource.previouslySyncedBitwardenAccountIds = setOf("1", "2")
+        assertEquals(
+            setOf("1", "2"),
+            settingDiskSource.previouslySyncedBitwardenAccountIds,
+        )
+    }
 }

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryTest.kt
@@ -92,4 +92,22 @@ class SettingsRepositoryTest {
         settingsRepository.defaultSaveOption = DefaultSaveOption.BITWARDEN_APP
         verify { settingsDiskSource.defaultSaveOption = DefaultSaveOption.BITWARDEN_APP }
     }
+
+    @Test
+    fun `previouslySyncedBitwardenAccountIds should pull from and update SettingsDiskSource`() {
+        // Reading from repository should read from disk source:
+        every { settingsDiskSource.previouslySyncedBitwardenAccountIds } returns emptySet()
+        assertEquals(
+            emptySet<String>(),
+            settingsRepository.previouslySyncedBitwardenAccountIds,
+        )
+        verify { settingsDiskSource.previouslySyncedBitwardenAccountIds }
+
+        // Writing to repository should write to disk source:
+        every {
+            settingsDiskSource.previouslySyncedBitwardenAccountIds = setOf("1", "2", "3")
+        } just runs
+        settingsRepository.previouslySyncedBitwardenAccountIds = setOf("1", "2", "3")
+        verify { settingsDiskSource.previouslySyncedBitwardenAccountIds = setOf("1", "2", "3") }
+    }
 }

--- a/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -1,13 +1,13 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
-import androidx.room.util.copy
 import com.bitwarden.authenticator.data.platform.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.VerificationCodeDisplayItem
@@ -22,6 +22,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import org.junit.Before
 import org.junit.Test
 
@@ -238,6 +239,32 @@ class ItemListingScreenTest : BaseComposeTest() {
         composeTestRule
             .onNodeWithText("Move to Bitwarden")
             .assertDoesNotExist()
+    }
+
+    @Test
+    fun `on ShowFirstTimeSyncSnackbar receive should show snackbar`() {
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                viewState = ItemListingState.ViewState.Content(
+                    actionCard = ItemListingState.ActionCardState.None,
+                    favoriteItems = emptyList(),
+                    itemList = emptyList(),
+                    sharedItems = SharedCodesDisplayState.Codes(emptyList()),
+                ),
+            )
+        }
+        // Make sure the snackbar isn't showing:
+        composeTestRule
+            .onNodeWithText("Account synced from Bitwarden app")
+            .assertIsNotDisplayed()
+
+        // Send ShowFirstTimeSyncSnackbar event
+        mutableEventFlow.tryEmit(ItemListingEvent.ShowFirstTimeSyncSnackbar)
+
+        // Make sure the snackbar is showing:
+        composeTestRule
+            .onNodeWithText("Account synced from Bitwarden app")
+            .assertIsDisplayed()
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-84
https://livefront.atlassian.net/browse/BITAU-85

## 📔 Objective

The goal of this PR is to show a snackbar anytime a new account is synced with bitwarden.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a481146a-f34b-4d7b-8d05-afea4b87bf0b" width="300" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
