### PR TITLE
BITAU-189 BITAU-188 Only show default save option row when sync is en…

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -373,7 +373,7 @@ private fun DefaultSaveOptionSelectionRow(
     var shouldShowDefaultSaveOptionDialog by remember { mutableStateOf(false) }
 
     BitwardenTextRow(
-        text = stringResource(id = R.string.default_save_options),
+        text = stringResource(id = R.string.default_save_option),
         onClick = { shouldShowDefaultSaveOptionDialog = true },
         modifier = modifier,
         withDivider = true,
@@ -388,7 +388,7 @@ private fun DefaultSaveOptionSelectionRow(
     var dialogSelection by remember { mutableStateOf(currentSelection) }
     if (shouldShowDefaultSaveOptionDialog) {
         BitwardenSelectionDialog(
-            title = stringResource(id = R.string.default_save_options),
+            title = stringResource(id = R.string.default_save_option),
             subtitle = stringResource(id = R.string.default_save_options_subtitle),
             dismissLabel = stringResource(id = R.string.confirm),
             onDismissRequest = { shouldShowDefaultSaveOptionDialog = false },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,7 +133,7 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="please_try_again">Please try again</string>
     <string name="move_to_bitwarden">Move to Bitwarden</string>
-    <string name="default_save_options">Default save options</string>
+    <string name="default_save_option">Default save option</string>
     <string name="save_to_bitwarden">Save to Bitwarden</string>
     <string name="save_locally">Save locally</string>
     <string name="none">None</string>

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -119,32 +119,32 @@ class SettingsScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Default Save Options row should be hidden when showDefaultSaveOptionRow is false`() {
+    fun `Default Save Option row should be hidden when showDefaultSaveOptionRow is false`() {
         mutableStateFlow.value = DEFAULT_STATE
-        composeTestRule.onNodeWithText("Default save options").assertExists()
+        composeTestRule.onNodeWithText("Default save option").assertExists()
 
         mutableStateFlow.update {
             it.copy(
                 showDefaultSaveOptionRow = false,
             )
         }
-        composeTestRule.onNodeWithText("Default save options").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Default save option").assertDoesNotExist()
     }
 
     @Test
     @Suppress("MaxLineLength")
-    fun `Default Save Options dialog should send DefaultSaveOptionUpdated when confirm is clicked`() =
+    fun `Default Save Option dialog should send DefaultSaveOptionUpdated when confirm is clicked`() =
         runTest {
             val expectedSaveOption = DefaultSaveOption.BITWARDEN_APP
             mutableStateFlow.value = DEFAULT_STATE
             composeTestRule
-                .onNodeWithText("Default save options")
+                .onNodeWithText("Default save option")
                 .performScrollTo()
                 .performClick()
 
             // Make sure the dialog is showing:
             composeTestRule
-                .onAllNodesWithText("Default save options")
+                .onAllNodesWithText("Default save option")
                 .filterToOne(hasAnyAncestor(isDialog()))
                 .assertIsDisplayed()
 

--- a/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.authenticator.BuildConfig
 import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
+import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
+import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
 import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.bitwarden.authenticator.data.platform.manager.model.LocalFeatureFlag
@@ -19,11 +22,15 @@ import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -33,6 +40,11 @@ class SettingsViewModelTest : BaseViewModelTest() {
 
     private val authenticatorBridgeManager: AuthenticatorBridgeManager = mockk {
         every { accountSyncStateFlow } returns MutableStateFlow(AccountSyncState.Loading)
+    }
+
+    private val mutableSharedCodesFlow = MutableStateFlow(MOCK_SHARED_CODES_STATE)
+    private val authenticatorRepository: AuthenticatorRepository = mockk {
+        every { sharedCodesStateFlow } returns mutableSharedCodesFlow
     }
     private val settingsRepository: SettingsRepository = mockk {
         every { appLanguage } returns APP_LANGUAGE
@@ -44,6 +56,16 @@ class SettingsViewModelTest : BaseViewModelTest() {
     private val clipboardManager: BitwardenClipboardManager = mockk()
     private val featureFlagManager: FeatureFlagManager = mockk {
         every { getFeatureFlag(LocalFeatureFlag.PasswordManagerSync) } returns true
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SharedVerificationCodesState::isSyncWithBitwardenEnabled)
+        every { MOCK_SHARED_CODES_STATE.isSyncWithBitwardenEnabled } returns false
+    }
+
+    fun teardown() {
+        unmockkStatic(SharedVerificationCodesState::isSyncWithBitwardenEnabled)
     }
 
     @Test
@@ -132,6 +154,29 @@ class SettingsViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
+    fun `Default save option row should only show when shared codes state shows syncing as enabled`() =
+        runTest {
+            val viewModel = createViewModel()
+            val enabledState: SharedVerificationCodesState = mockk {
+                every { isSyncWithBitwardenEnabled } returns true
+            }
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_STATE,
+                    awaitItem(),
+                )
+                mutableSharedCodesFlow.update { enabledState }
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        showDefaultSaveOptionRow = true,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
     fun `on DefaultSaveOptionUpdated should update SettingsRepository and state`() {
         val expectedOption = DefaultSaveOption.BITWARDEN_APP
         every { settingsRepository.defaultSaveOption = expectedOption } just runs
@@ -154,12 +199,14 @@ class SettingsViewModelTest : BaseViewModelTest() {
         savedStateHandle = SavedStateHandle().apply { this["state"] = savedState },
         clock = CLOCK,
         authenticatorBridgeManager = authenticatorBridgeManager,
+        authenticatorRepository = authenticatorRepository,
         settingsRepository = settingsRepository,
         clipboardManager = clipboardManager,
         featureFlagManager = featureFlagManager,
     )
 }
 
+private val MOCK_SHARED_CODES_STATE: SharedVerificationCodesState = mockk()
 private val APP_LANGUAGE = AppLanguage.ENGLISH
 private val APP_THEME = AppTheme.DEFAULT
 private val CLOCK = Clock.fixed(
@@ -175,7 +222,7 @@ private val DEFAULT_STATE = SettingsState(
     isSubmitCrashLogsEnabled = true,
     isUnlockWithBiometricsEnabled = true,
     showSyncWithBitwarden = true,
-    showDefaultSaveOptionRow = true,
+    showDefaultSaveOptionRow = false,
     defaultSaveOption = DEFAULT_SAVE_OPTION,
     dialog = null,
     version = R.string.version.asText()


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-189
https://livefront.atlassian.net/browse/BITAU-188

## 📔 Objective

The goal of this PR is to only show the default save option row when a user has enabled authenticator sync.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/ff100f0d-7f01-48d7-89c8-076a736df062" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
