### PR TITLE
Disable ExtraTranslation lint check

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,7 +100,10 @@ android {
         }
     }
     lint {
-        disable.add("MissingTranslation")
+        disable += listOf(
+            "MissingTranslation",
+            "ExtraTranslation",
+        )
     }
     @Suppress("UnstableApiUsage")
     testOptions {


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

This commit disables the `ExtraTranslation` lint check in addition to the existing `MissingTranslation` check. This is done by adding it to the list of disabled lint checks within the `lint` block of the build configuration.

Unblocks #260 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
