### PR TITLE
BITAU-184 Allow user to save to Bitwarden when adding a code manually

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -37,7 +37,6 @@ import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.base.util.EventsEffect
 import com.bitwarden.authenticator.ui.platform.base.util.toAnnotatedString
 import com.bitwarden.authenticator.ui.platform.components.appbar.BitwardenTopAppBar
-import com.bitwarden.authenticator.ui.platform.components.button.BitwardenFilledTonalButton
 import com.bitwarden.authenticator.ui.platform.components.dialog.BasicDialogState
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenLoadingDialog
@@ -201,17 +200,19 @@ fun ManualCodeEntryScreen(
             )
 
             Spacer(modifier = Modifier.height(16.dp))
-            BitwardenFilledTonalButton(
-                label = stringResource(id = R.string.add_code),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(ManualCodeEntryAction.CodeSubmit) }
+            SaveManualCodeButtons(
+                state = state.buttonState,
+                onSaveLocallyClick = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(ManualCodeEntryAction.SaveLocallyClick)
+                    }
                 },
-                modifier = Modifier
-                    .semantics { testTag = "AddCodeButton" }
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                onSaveToBitwardenClick = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(ManualCodeEntryAction.SaveToBitwardenClick)
+                    }
+                },
             )
-
             Text(
                 text = stringResource(id = R.string.once_the_key_is_successfully_entered),
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -181,7 +181,7 @@ private fun deriveButtonState(
     sharedCodesState: SharedVerificationCodesState,
     defaultSaveOption: DefaultSaveOption,
 ): ManualCodeEntryState.ButtonState {
-    // If syncing with Bitwarden is not enabled, who local save only:
+    // If syncing with Bitwarden is not enabled, show local save only:
     if (!sharedCodesState.isSyncWithBitwardenEnabled) {
         return ManualCodeEntryState.ButtonState.LocalOnly
     }

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -8,10 +8,15 @@ import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.Aut
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
+import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
+import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
+import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.base.BaseViewModel
 import com.bitwarden.authenticator.ui.platform.base.util.Text
 import com.bitwarden.authenticator.ui.platform.base.util.asText
 import com.bitwarden.authenticator.ui.platform.base.util.isBase32
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,24 +31,37 @@ private const val KEY_STATE = "state"
  *
  */
 @HiltViewModel
+@Suppress("TooManyFunctions")
 class ManualCodeEntryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val authenticatorRepository: AuthenticatorRepository,
+    private val authenticatorBridgeManager: AuthenticatorBridgeManager,
+    settingsRepository: SettingsRepository,
 ) : BaseViewModel<ManualCodeEntryState, ManualCodeEntryEvent, ManualCodeEntryAction>(
     initialState = savedStateHandle[KEY_STATE]
-        ?: ManualCodeEntryState(code = "", issuer = "", dialog = null),
+        ?: ManualCodeEntryState(
+            code = "",
+            issuer = "",
+            dialog = null,
+            buttonState = deriveButtonState(
+                sharedCodesState = authenticatorRepository.sharedCodesStateFlow.value,
+                defaultSaveOption = settingsRepository.defaultSaveOption,
+            ),
+        ),
 ) {
     override fun handleAction(action: ManualCodeEntryAction) {
         when (action) {
             is ManualCodeEntryAction.CloseClick -> handleCloseClick()
             is ManualCodeEntryAction.CodeTextChange -> handleCodeTextChange(action)
             is ManualCodeEntryAction.IssuerTextChange -> handleIssuerTextChange(action)
-            is ManualCodeEntryAction.CodeSubmit -> handleCodeSubmit()
             is ManualCodeEntryAction.ScanQrCodeTextClick -> handleScanQrCodeTextClick()
             is ManualCodeEntryAction.SettingsClick -> handleSettingsClick()
             ManualCodeEntryAction.DismissDialog -> {
                 handleDialogDismiss()
             }
+
+            ManualCodeEntryAction.SaveLocallyClick -> handleSaveLocallyClick()
+            ManualCodeEntryAction.SaveToBitwardenClick -> handleSaveToBitwardenClick()
         }
     }
 
@@ -67,7 +85,12 @@ class ManualCodeEntryViewModel @Inject constructor(
         }
     }
 
-    private fun handleCodeSubmit() {
+    private fun handleSaveLocallyClick() = handleCodeSubmit(saveToBitwarden = false)
+
+    private fun handleSaveToBitwardenClick() = handleCodeSubmit(saveToBitwarden = true)
+
+    @Suppress("LongMethod")
+    private fun handleCodeSubmit(saveToBitwarden: Boolean) {
         val isSteamCode = state.code.startsWith(TotpCodeManager.STEAM_CODE_PREFIX)
         val sanitizedCode = state.code
             .replace(" ", "")
@@ -87,30 +110,51 @@ class ManualCodeEntryViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch {
-            authenticatorRepository.createItem(
-                AuthenticatorItemEntity(
-                    id = UUID.randomUUID().toString(),
-                    key = sanitizedCode,
-                    issuer = state.issuer,
-                    accountName = "",
-                    userId = null,
-                    type = if (isSteamCode) {
-                        AuthenticatorItemType.STEAM
-                    } else {
-                        AuthenticatorItemType.TOTP
-                    },
-                    favorite = false,
-                ),
-            )
-            sendEvent(
-                event = ManualCodeEntryEvent.ShowToast(
-                    message = R.string.verification_code_added.asText(),
-                ),
-            )
-            sendEvent(
-                event = ManualCodeEntryEvent.NavigateBack,
-            )
+        if (saveToBitwarden) {
+            // Save to Bitwarden by kicking off save to Bitwarden flow:
+            val didLaunchSaveToBitwarden = authenticatorBridgeManager
+                .startAddTotpLoginItemFlow(
+                    totpUri = "otpauth://totp/?secret=$sanitizedCode&issuer=${state.issuer}",
+                )
+            if (!didLaunchSaveToBitwarden) {
+                mutableStateFlow.update {
+                    it.copy(
+                        dialog = ManualCodeEntryState.DialogState.Error(
+                            title = R.string.something_went_wrong.asText(),
+                            message = R.string.please_try_again.asText(),
+                        ),
+                    )
+                }
+            } else {
+                sendEvent(ManualCodeEntryEvent.NavigateBack)
+            }
+        } else {
+            // Save locally by giving entity to AuthRepository and navigating back:
+            viewModelScope.launch {
+                authenticatorRepository.createItem(
+                    AuthenticatorItemEntity(
+                        id = UUID.randomUUID().toString(),
+                        key = sanitizedCode,
+                        issuer = state.issuer,
+                        accountName = "",
+                        userId = null,
+                        type = if (isSteamCode) {
+                            AuthenticatorItemType.STEAM
+                        } else {
+                            AuthenticatorItemType.TOTP
+                        },
+                        favorite = false,
+                    ),
+                )
+                sendEvent(
+                    event = ManualCodeEntryEvent.ShowToast(
+                        message = R.string.verification_code_added.asText(),
+                    ),
+                )
+                sendEvent(
+                    event = ManualCodeEntryEvent.NavigateBack,
+                )
+            }
         }
     }
 
@@ -133,6 +177,22 @@ class ManualCodeEntryViewModel @Inject constructor(
     }
 }
 
+private fun deriveButtonState(
+    sharedCodesState: SharedVerificationCodesState,
+    defaultSaveOption: DefaultSaveOption,
+): ManualCodeEntryState.ButtonState {
+    // If syncing with Bitwarden is not enabled, who local save only:
+    if (!sharedCodesState.isSyncWithBitwardenEnabled) {
+        return ManualCodeEntryState.ButtonState.LocalOnly
+    }
+    // Otherwise, show save options based on user's preferences:
+    return when (defaultSaveOption) {
+        DefaultSaveOption.NONE -> ManualCodeEntryState.ButtonState.SaveToBitwardenPrimary
+        DefaultSaveOption.BITWARDEN_APP -> ManualCodeEntryState.ButtonState.SaveToBitwardenPrimary
+        DefaultSaveOption.LOCAL -> ManualCodeEntryState.ButtonState.SaveLocallyPrimary
+    }
+}
+
 /**
  * Models state of the manual entry screen.
  */
@@ -141,6 +201,7 @@ data class ManualCodeEntryState(
     val code: String,
     val issuer: String,
     val dialog: DialogState?,
+    val buttonState: ButtonState,
 ) : Parcelable {
 
     /**
@@ -165,6 +226,31 @@ data class ManualCodeEntryState(
         data class Loading(
             val message: Text,
         ) : DialogState()
+    }
+
+    /**
+     * Models what variation of button states should be shown.
+     */
+    @Parcelize
+    sealed class ButtonState : Parcelable {
+
+        /**
+         * Show only save locally option.
+         */
+        @Parcelize
+        data object LocalOnly : ButtonState()
+
+        /**
+         * Show both save locally and save to Bitwarden, with Bitwarden being the primary option.
+         */
+        @Parcelize
+        data object SaveToBitwardenPrimary : ButtonState()
+
+        /**
+         * Show both save locally and save to Bitwarden, with locally being the primary option.
+         */
+        @Parcelize
+        data object SaveLocallyPrimary : ButtonState()
     }
 }
 
@@ -205,9 +291,14 @@ sealed class ManualCodeEntryAction {
     data object CloseClick : ManualCodeEntryAction()
 
     /**
-     * The user has submitted a code.
+     * The user clicked the save locally button.
      */
-    data object CodeSubmit : ManualCodeEntryAction()
+    data object SaveLocallyClick : ManualCodeEntryAction()
+
+    /**
+     * Th user clicked the save to Bitwarden button.
+     */
+    data object SaveToBitwardenClick : ManualCodeEntryAction()
 
     /**
      * The user has changed the code text.

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
@@ -1,0 +1,81 @@
+package com.bitwarden.authenticator.ui.authenticator.feature.manualcodeentry
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.components.button.BitwardenFilledButton
+import com.bitwarden.authenticator.ui.platform.components.button.BitwardenFilledTonalButton
+import com.bitwarden.authenticator.ui.platform.components.button.BitwardenOutlinedButton
+
+/**
+ * Displays save buttons for saving a manually entered code.
+ *
+ * @param state State of the buttons to show.
+ * @param onSaveLocallyClick Callback invoked when the user clicks save locally.
+ * @param onSaveToBitwardenClick Callback invoked when the user clicks save to Bitwarden.
+ */
+@Composable
+fun SaveManualCodeButtons(
+    state: ManualCodeEntryState.ButtonState,
+    onSaveLocallyClick: () -> Unit,
+    onSaveToBitwardenClick: () -> Unit,
+) {
+
+    when (state) {
+        ManualCodeEntryState.ButtonState.LocalOnly -> {
+            BitwardenFilledTonalButton(
+                label = stringResource(id = R.string.add_code),
+                onClick = onSaveLocallyClick,
+                modifier = Modifier
+                    .semantics { testTag = "AddCodeButton" }
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
+        }
+
+        ManualCodeEntryState.ButtonState.SaveLocallyPrimary -> {
+            Column {
+                BitwardenFilledButton(
+                    label = stringResource(id = R.string.add_code_locally),
+                    onClick = onSaveLocallyClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+                BitwardenOutlinedButton(
+                    label = stringResource(R.string.add_code_to_bitwarden),
+                    onClick = onSaveToBitwardenClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+            }
+        }
+
+        ManualCodeEntryState.ButtonState.SaveToBitwardenPrimary -> {
+            Column {
+                BitwardenFilledButton(
+                    label = stringResource(id = R.string.add_code_to_bitwarden),
+                    onClick = onSaveToBitwardenClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+                BitwardenOutlinedButton(
+                    label = stringResource(R.string.add_code_locally),
+                    onClick = onSaveLocallyClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,4 +145,6 @@
     <string name="choose_save_location_message">Save this authenticator key here, or add it to a login in your Bitwarden app.</string>
     <string name="save_option_as_default">Save option as default</string>
     <string name="account_synced_from_bitwarden_app">Account synced from Bitwarden app</string>
+    <string name="add_code_to_bitwarden">Add code to Bitwarden</string>
+    <string name="add_code_locally">Add code locally</string>
 </resources>

--- a/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
@@ -1,0 +1,111 @@
+package com.bitwarden.authenticator.ui.authenticator.feature.manualcodeentry
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.bitwarden.authenticator.data.platform.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.authenticator.ui.platform.base.BaseComposeTest
+import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
+import com.bitwarden.authenticator.ui.platform.manager.permissions.FakePermissionManager
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import org.junit.Before
+import org.junit.Test
+
+class ManualCodeEntryScreenTest : BaseComposeTest() {
+
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
+    private val mutableEventFlow = bufferedMutableSharedFlow<ManualCodeEntryEvent>()
+
+    private val viewModel: ManualCodeEntryViewModel = mockk {
+        every { stateFlow } returns mutableStateFlow
+        every { eventFlow } returns mutableEventFlow
+        every { trySendAction(any()) } just runs
+    }
+
+    private val intentManager: IntentManager = mockk()
+    private val permissionsManager = FakePermissionManager()
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            ManualCodeEntryScreen(
+                onNavigateBack = {},
+                onNavigateToQrCodeScreen = {},
+                viewModel = viewModel,
+                intentManager = intentManager,
+                permissionsManager = permissionsManager,
+            )
+        }
+    }
+
+    @Test
+    fun `on Add code click should emit SaveLocallyClick`() {
+        composeTestRule
+            .onNodeWithText("Add code")
+            .performClick()
+
+        // Make sure save to bitwaren isn't showing:
+        composeTestRule
+            .onNodeWithText("Add code to Bitwarden")
+            .assertDoesNotExist()
+
+        verify { viewModel.trySendAction(ManualCodeEntryAction.SaveLocallyClick) }
+    }
+
+    @Test
+    fun `on Add code to Bitwarden click should emit SaveToBitwardenClick`() {
+        mutableStateFlow.update {
+            it.copy(buttonState = ManualCodeEntryState.ButtonState.SaveToBitwardenPrimary)
+        }
+        composeTestRule
+            .onNodeWithText("Add code to Bitwarden")
+            .performClick()
+
+        // Make sure locally only save isn't showing:
+        composeTestRule
+            .onNodeWithText("Add code")
+            .assertDoesNotExist()
+
+        // Make sure locally option is showing:
+        composeTestRule
+            .onNodeWithText("Add code locally")
+            .assertIsDisplayed()
+
+        verify { viewModel.trySendAction(ManualCodeEntryAction.SaveToBitwardenClick) }
+    }
+
+    @Test
+    fun `on Add code locally click should emit SaveLocallyClick`() {
+        mutableStateFlow.update {
+            it.copy(buttonState = ManualCodeEntryState.ButtonState.SaveLocallyPrimary)
+        }
+        composeTestRule
+            .onNodeWithText("Add code locally")
+            .performClick()
+
+        // Make sure locally only save isn't showing:
+        composeTestRule
+            .onNodeWithText("Add code")
+            .assertDoesNotExist()
+
+        // Make sure save to bitwarden option is showing:
+        composeTestRule
+            .onNodeWithText("Add code to Bitwarden")
+            .assertIsDisplayed()
+
+        verify { viewModel.trySendAction(ManualCodeEntryAction.SaveLocallyClick) }
+    }
+}
+
+private val DEFAULT_STATE = ManualCodeEntryState(
+    code = "",
+    issuer = "",
+    dialog = null,
+    buttonState = ManualCodeEntryState.ButtonState.LocalOnly,
+)


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-184

## 📔 Objective

The goal here is to update the manual entry screen to allow for saving to Bitwarden. If the sync is not enabled, the save button should always be save locally. If sync is enabled, the save button should show the primary action (either save local or save to bitwarden) based on what the user has selected as their default save location.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/e71f6661-1322-4bb5-88f2-1193d8765170" width="300" />




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
