### PR TITLE
BITAU-89 Have SettingsViewModel obsererve DefaultSaveOption

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -31,6 +31,11 @@ interface SettingsDiskSource {
     var defaultSaveOption: DefaultSaveOption
 
     /**
+     * Flow that emits changes to [defaultSaveOption]
+     */
+    val defaultSaveOptionFlow: Flow<DefaultSaveOption>
+
+    /**
      * The currently persisted biometric integrity source for the system.
      */
     var systemBiometricIntegritySource: String?

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -45,6 +45,9 @@ class SettingsDiskSourceImpl(
     private val mutableIsCrashLoggingEnabledFlow =
         bufferedMutableSharedFlow<Boolean?>()
 
+    private val mutableDefaultSaveOptionFlow =
+        bufferedMutableSharedFlow<DefaultSaveOption>()
+
     override var appLanguage: AppLanguage?
         get() = getString(key = APP_LANGUAGE_KEY)
             ?.let { storedValue ->
@@ -89,7 +92,11 @@ class SettingsDiskSourceImpl(
                 key = DEFAULT_SAVE_OPTION_KEY,
                 value = newValue.value,
             )
+            mutableDefaultSaveOptionFlow.tryEmit(newValue)
         }
+    override val defaultSaveOptionFlow: Flow<DefaultSaveOption>
+        get() = mutableDefaultSaveOptionFlow
+            .onSubscription { emit(defaultSaveOption) }
 
     override var systemBiometricIntegritySource: String?
         get() = getString(key = SYSTEM_BIOMETRIC_INTEGRITY_SOURCE_KEY)

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepository.kt
@@ -38,6 +38,11 @@ interface SettingsRepository {
     var defaultSaveOption: DefaultSaveOption
 
     /**
+     * Flow that emits changes to [defaultSaveOption]
+     */
+    val defaultSaveOptionFlow: Flow<DefaultSaveOption>
+
+    /**
      * Whether or not biometric unlocking is enabled for the current user.
      */
     val isUnlockWithBiometricsEnabled: Boolean

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
@@ -43,6 +43,8 @@ class SettingsRepositoryImpl(
     override var authenticatorAlertThresholdSeconds = settingsDiskSource.getAlertThresholdSeconds()
 
     override var defaultSaveOption: DefaultSaveOption by settingsDiskSource::defaultSaveOption
+    override val defaultSaveOptionFlow: Flow<DefaultSaveOption>
+        by settingsDiskSource::defaultSaveOptionFlow
 
     override val isUnlockWithBiometricsEnabled: Boolean
         get() = authDiskSource.getUserBiometricUnlockKey() != null

--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/repository/SettingsRepositoryImpl.kt
@@ -43,6 +43,7 @@ class SettingsRepositoryImpl(
     override var authenticatorAlertThresholdSeconds = settingsDiskSource.getAlertThresholdSeconds()
 
     override var defaultSaveOption: DefaultSaveOption by settingsDiskSource::defaultSaveOption
+
     override val defaultSaveOptionFlow: Flow<DefaultSaveOption>
         by settingsDiskSource::defaultSaveOptionFlow
 

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
@@ -72,6 +72,12 @@ class SettingsViewModel @Inject constructor(
             .map { SettingsAction.Internal.SharedAccountsStateUpdated(it) }
             .onEach(::handleAction)
             .launchIn(viewModelScope)
+
+        settingsRepository
+            .defaultSaveOptionFlow
+            .map { SettingsAction.Internal.DefaultSaveOptionUpdated(it) }
+            .onEach(::handleAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: SettingsAction) {
@@ -102,6 +108,10 @@ class SettingsViewModel @Inject constructor(
 
             is SettingsAction.Internal.SharedAccountsStateUpdated -> {
                 handleSharedAccountsStateUpdated(action)
+            }
+
+            is SettingsAction.Internal.DefaultSaveOptionUpdated -> {
+                handleDefaultSaveOptionUpdated(action)
             }
         }
     }
@@ -175,14 +185,19 @@ class SettingsViewModel @Inject constructor(
             SettingsAction.DataClick.BackupClick -> handleBackupClick()
             SettingsAction.DataClick.SyncWithBitwardenClick -> handleSyncWithBitwardenClick()
             is SettingsAction.DataClick.DefaultSaveOptionUpdated ->
-                handleDefaultSaveOptionUpdated(action)
+                handleDefaultSaveOptionChosen(action)
         }
     }
 
-    private fun handleDefaultSaveOptionUpdated(
+    private fun handleDefaultSaveOptionChosen(
         action: SettingsAction.DataClick.DefaultSaveOptionUpdated,
     ) {
         settingsRepository.defaultSaveOption = action.option
+    }
+
+    private fun handleDefaultSaveOptionUpdated(
+        action: SettingsAction.Internal.DefaultSaveOptionUpdated,
+    ) {
         mutableStateFlow.update {
             it.copy(
                 defaultSaveOption = action.option,
@@ -552,6 +567,13 @@ sealed class SettingsAction(
          */
         data class SharedAccountsStateUpdated(
             val state: SharedVerificationCodesState,
+        ) : SettingsAction()
+
+        /**
+         * Indicates that the default save option on disk was updated.
+         */
+        data class DefaultSaveOptionUpdated(
+            val option: DefaultSaveOption,
         ) : SettingsAction()
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-89

## 📔 Objective

The goal here is to have the settings screen observe default save option instead of just grabbing it once.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/8e6a022a-d1e7-4113-baf3-ddd195ccfd8e" width="300" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
