### PR TITLE
BITAU-193 Make first time sync snackbar correct in dark theme

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
@@ -37,11 +37,11 @@ fun FirstTimeSyncSnackbarHost(
                 modifier = Modifier
                     .padding(16.dp)
                     .fillMaxWidth()
+                    .shadow(elevation = 6.dp)
                     .background(
                         color = MaterialTheme.colorScheme.inverseSurface,
                         shape = RoundedCornerShape(8.dp),
-                    )
-                    .shadow(elevation = 6.dp),
+                    ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-193

## 📔 Objective

This was showing up very janky in dark theme, now its not!

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/18ec06b8-f3a0-4cae-aafb-b05d9816b113" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
