### PR TITLE
[BWA-33]: Publish release bundles to Play Store when requested

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,22 @@ jobs:
           az storage blob download --account-name $ACCOUNT_NAME --container-name $CONTAINER_NAME \
           --name authenticator_play_firebase-creds.json --file ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json --output none
 
+      - name: Download Play Store credentials
+        if: ${{ inputs.publish-to-play-store }}
+        env:
+          ACCOUNT_NAME: bitwardenci
+          CONTAINER_NAME: mobile
+        run: |
+          mkdir -p ${{ github.workspace }}/secrets
+
+          az storage blob download --account-name $ACCOUNT_NAME --container-name $CONTAINER_NAME \
+          --name authenticator_play_store-creds.json --file ${{ github.workspace }}/secrets/authenticator_play_store-creds.json --output none
+
+      - name: Verify Play Store credentials
+        if: ${{ inputs.publish-to-play-store }}
+        run: |
+          bundle exec fastlane run validate_play_store_json_key
+
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
 
@@ -167,14 +183,19 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Increment version
-        env:
-          FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |
           DEFAULT_VERSION_CODE=$GITHUB_RUN_NUMBER
+          VERSION_CODE="${{ inputs.version-code || '$DEFAULT_VERSION_CODE' }}"
           bundle exec fastlane setBuildVersionInfo \
-          serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }} \
-          versionCode:${{ inputs.version-code || '$DEFAULT_VERSION_CODE' }} \
-          versionName:${{ inputs.version-name }}
+          versionCode:$VERSION_CODE \
+          versionName:${{ inputs.version-name || '' }}
+
+          regex='versionName = "([^"]+)"'
+          if [[ "$(cat app/build.gradle.kts)" =~ $regex ]]; then
+            VERSION_NAME="${BASH_REMATCH[1]}"
+          fi
+          echo "Version Name: ${VERSION_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "Version Number: $VERSION_CODE" >> $GITHUB_STEP_SUMMARY
 
       - name: Generate release Play Store bundle
         if: ${{ matrix.variant == 'aab' }}
@@ -255,7 +276,7 @@ jobs:
       - name: Publish release bundle to Google Play Store
         if: ${{ inputs.publish-to-play-store && matrix.variant == 'aab' }}
         env:
-          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
+          PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_store-creds.json
         run: |
           bundle exec fastlane publishReleaseToGooglePlayStore \
           serviceCredentialsFile:${{ env.PLAY_STORE_CREDS_FILE }} \

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,1 +1,2 @@
+json_key_file("secrets/authenticator_play_store-creds.json")
 package_name("com.bitwarden.authenticator")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,20 +32,37 @@ platform :android do
     buildConfigText = buildConfigFile.read
     buildConfigFile.close
 
+    currentVersionCode = buildConfigText.match(/versionCode = (\d+)/).captures[0]
+    currentVersionName = buildConfigText.match(/versionName = "(.+)"/).captures[0]
+
     if options[:versionName].nil? or options[:versionName].to_s.empty?
-        # Use the latest version name in Firebase as the default version name.
-        latestRelease = firebase_app_distribution_get_latest_release(
-          app: "1:867301491091:android:50b626dba42a361651e866",
-          service_credentials_file:options[:serviceCredentialsFile]
-        )
-        nextVersionName = latestRelease[:displayVersion]
+        puts "Fetching latest tags from origin..."
+        `git fetch --prune --no-recurse-submodules --filter=tree:0 --depth=1 --tags origin`
+        puts "Getting latest version name from previous git tag..."
+        latestTag = `git describe --tags $(git rev-list --tags --max-count=1)`.chomp()
+        puts "Using tag #{latestTag} to calculate version name..."
+        latestTag.slice!(0)
+        puts "Current version name resolved to #{latestTag}."
+
+        versionParts = latestTag.split(".")
+        currentMajor = versionParts[0]
+        currentMinor = versionParts[1]
+        currentRevision = versionParts[2]
+
+        currentDate = Time.new
+        major = currentDate.year.to_s
+        minor = currentDate.strftime "%-m"
+
+        revision = 0
+        if currentMajor == major and currentMinor == minor
+            revision = currentRevision.to_i + 1
+        end
+        nextVersionName = "#{major}.#{minor}.#{revision}"
     else
         nextVersionName = options[:versionName].to_s
     end
 
     # Replace version information.
-    currentVersionCode = buildConfigText.match(/versionCode = (\d+)/).captures[0]
-    currentVersionName = buildConfigText.match(/versionName = "(.+)"/).captures[0]
     puts "Setting version code to #{options[:versionCode]}."
     buildConfigText.gsub!("versionCode = #{currentVersionCode}", "versionCode = #{options[:versionCode]}")
     puts "Setting version name to #{nextVersionName}."


### PR DESCRIPTION
## 🎟️ Tracking

BWA-33

## 📔 Objective

Downloads the `authenticator_play_store-creds.json` file from Azure blob storage and uses it for publishing to the Google Play Store.

Automatically determine the next version name based on git tags.

If the major and minor versions match the current date, increment the revision. Otherwise, start a new version based on the year and month.

Display version name and code in the workflow summary.

Allow overriding version code and name via workflow inputs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
