### PR TITLE
BWA-118 Tutorial text cut off in landscape mode

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,7 +53,7 @@ import com.bitwarden.authenticator.ui.platform.util.isPortrait
 /**
  * The custom horizontal margin that is specific to this screen.
  */
-private val LANDSCAPE_HORIZONTAL_MARGIN: Dp = 128.dp
+private val LANDSCAPE_HORIZONTAL_MARGIN: Dp = 48.dp
 
 /**
  * Top level composable for the tutorial screen.
@@ -98,6 +101,7 @@ fun TutorialScreen(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun TutorialScreenContent(
     state: TutorialState,
@@ -114,21 +118,30 @@ private fun TutorialScreenContent(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
     ) {
         Spacer(modifier = Modifier.weight(1f))
 
-        HorizontalPager(state = pagerState) { index ->
+        HorizontalPager(
+            state = pagerState,
+            beyondViewportPageCount = pagerState.pageCount,
+            modifier = Modifier.fillMaxWidth(),
+        ) { index ->
             if (LocalConfiguration.current.isPortrait) {
                 TutorialScreenPortrait(
                     state = state.pages[index],
-                    modifier = Modifier.standardHorizontalMargin(),
+                    modifier = Modifier
+                        .standardHorizontalMargin()
+                        .statusBarsPadding(),
                 )
             } else {
                 TutorialScreenLandscape(
                     state = state.pages[index],
                     modifier = Modifier
-                        .standardHorizontalMargin(landscape = LANDSCAPE_HORIZONTAL_MARGIN),
+                        .standardHorizontalMargin(landscape = LANDSCAPE_HORIZONTAL_MARGIN)
+                        .statusBarsPadding(),
                 )
             }
         }
@@ -212,9 +225,10 @@ private fun TutorialScreenLandscape(
         Image(
             painter = rememberVectorPainter(id = state.image),
             contentDescription = null,
-            modifier = Modifier
-                .size(132.dp),
+            modifier = Modifier.size(132.dp),
         )
+
+        Spacer(modifier = Modifier.weight(1f))
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -233,6 +247,8 @@ private fun TutorialScreenLandscape(
                 style = MaterialTheme.typography.bodyLarge,
             )
         }
+
+        Spacer(modifier = Modifier.weight(1f))
     }
 }
 

--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -126,7 +126,6 @@ private fun TutorialScreenContent(
 
         HorizontalPager(
             state = pagerState,
-            beyondViewportPageCount = pagerState.pageCount,
             modifier = Modifier.fillMaxWidth(),
         ) { index ->
             if (LocalConfiguration.current.isPortrait) {

--- a/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialScreenTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialScreenTest.kt
@@ -3,6 +3,7 @@ package com.bitwarden.authenticator.ui.authenticator.feature.tutorial
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.bitwarden.authenticator.data.platform.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.authenticator.ui.platform.base.BaseComposeTest
 import com.bitwarden.authenticator.ui.platform.feature.tutorial.TutorialAction
@@ -116,6 +117,7 @@ class TutorialScreenTest : BaseComposeTest() {
     fun `skip button click should send SkipClick action`() {
         composeTestRule
             .onNodeWithText("Skip")
+            .performScrollTo()
             .performClick()
         verify { viewModel.trySendAction(TutorialAction.SkipClick) }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-118](https://bitwarden.atlassian.net/browse/BWA-118)

## 📔 Objective

- Portions of the tutorial text are cut off or not visible when the app is rotated to landscape mode during the tutorial.

## 📸 Screenshots

![Small Phone](https://github.com/user-attachments/assets/e5c9977f-3642-427b-b708-257d682000b4)
![Pixel 9 Pro](https://github.com/user-attachments/assets/46b44a3b-68bb-4c71-a8ac-8f94ae8f06bf)
<video src="https://github.com/user-attachments/assets/cd54c578-f15f-4c0e-b9f9-46546c82ac93"/>


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-118]: https://bitwarden.atlassian.net/browse/BWA-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ