### PR TITLE
BWA-144 - Consolidate feature flags for sync between the Password Manager Authenticator

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
@@ -45,7 +45,7 @@ sealed class FlagKey<out T : Any> {
      * Indicates whether syncing with the main Bitwarden password manager app should be enabled..
      */
     data object PasswordManagerSync : FlagKey<Boolean>() {
-        override val keyName: String = "enable-password-manager-sync-android"
+        override val keyName: String = "enable-pm-bwa-sync"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = true
     }

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -21,12 +21,12 @@ class FlagKeyTest {
 
     @Test
     fun `All feature flags have the correct default value set`() {
-        assertFalse(
+        assertTrue(
             listOf(
                 FlagKey.BitwardenAuthenticationEnabled,
                 FlagKey.PasswordManagerSync,
             ).all {
-                it.defaultValue
+                !it.defaultValue
             },
         )
     }

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -25,7 +25,7 @@ class FlagKeyTest {
             listOf(
                 FlagKey.BitwardenAuthenticationEnabled,
                 FlagKey.PasswordManagerSync,
-            ).any {
+            ).all {
                 it.defaultValue
             },
         )

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -1,0 +1,39 @@
+package com.bitwarden.authenticator.data.platform.manager
+
+import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FlagKeyTest {
+    @Test
+    fun `Feature flags have the correct key name set`() {
+        assertEquals(
+            FlagKey.BitwardenAuthenticationEnabled.keyName,
+            "bitwarden-authentication-enabled",
+        )
+        assertEquals(
+            FlagKey.PasswordManagerSync.keyName,
+            "enable-pm-bwa-sync",
+        )
+    }
+
+    @Test
+    fun `All feature flags have the correct default value set`() {
+        assertFalse(
+            listOf(
+                FlagKey.BitwardenAuthenticationEnabled,
+                FlagKey.PasswordManagerSync,
+            ).any {
+                it.defaultValue
+            }
+        )
+    }
+
+    @Test
+    fun `All feature flags are correctly set to be remotely configured`() {
+        assertTrue(FlagKey.PasswordManagerSync.isRemotelyConfigured)
+        assertFalse(FlagKey.BitwardenAuthenticationEnabled.isRemotelyConfigured)
+    }
+}

--- a/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -27,7 +27,7 @@ class FlagKeyTest {
                 FlagKey.PasswordManagerSync,
             ).any {
                 it.defaultValue
-            }
+            },
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-144](https://bitwarden.atlassian.net/browse/BWA-144)

## 📔 Objective

- Update Authenticator Sync feature flag name to `enable-pm-bwa-sync`

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-144]: https://bitwarden.atlassian.net/browse/BWA-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ