### PR TITLE
Rename Fastfile lanes to be Authenticator-specific

### DIFF
--- a/.github/workflows/build_authenticator.yml
+++ b/.github/workflows/build_authenticator.yml
@@ -81,7 +81,7 @@ jobs:
         run: bundle exec fastlane checkAuthenticator
 
       - name: Build Authenticator
-        run: bundle exec fastlane buildDebugAuthenticator
+        run: bundle exec fastlane buildAuthenticatorDebug
 
   publish_playstore:
     name: Publish Authenticator Play Store artifacts
@@ -152,7 +152,8 @@ jobs:
       - name: Verify Play Store credentials
         if: ${{ inputs.publish-to-play-store }}
         run: |
-          bundle exec fastlane run validate_play_store_json_key
+          bundle exec fastlane run validate_play_store_json_key \
+          json_key:${{ github.workspace }}/secrets/authenticator_play_store-creds.json }}
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
@@ -186,7 +187,7 @@ jobs:
         run: |
           DEFAULT_VERSION_CODE=$GITHUB_RUN_NUMBER
           VERSION_CODE="${{ inputs.version-code || '$DEFAULT_VERSION_CODE' }}"
-          bundle exec fastlane setBuildVersionInfoAuthenticator \
+          bundle exec fastlane setAuthenticatorBuildVersionInfo \
           versionCode:$VERSION_CODE \
           versionName:${{ inputs.version-name || '' }}
 
@@ -200,7 +201,7 @@ jobs:
       - name: Generate release Play Store bundle
         if: ${{ matrix.variant == 'aab' }}
         run: |
-          bundle exec fastlane bundleReleaseAuthenticator \
+          bundle exec fastlane bundleAuthenticatorRelease \
           storeFile:${{ github.workspace }}/keystores/authenticator_aab-keystore.jks \
           storePassword:'${{ secrets.AAB_KEYSTORE_STORE_PASSWORD }}' \
           keyAlias:authenticatorupload \
@@ -209,7 +210,7 @@ jobs:
       - name: Generate release Play Store APK
         if: ${{ matrix.variant == 'apk' }}
         run: |
-          bundle exec fastlane buildReleaseAuthenticator \
+          bundle exec fastlane buildAuthenticatorRelease \
           storeFile:${{ github.workspace }}/keystores/authenticator_apk-keystore.jks \
           storePassword:'${{ secrets.APK_KEYSTORE_STORE_PASSWORD }}' \
           keyAlias:bitwardenauthenticator \
@@ -268,7 +269,7 @@ jobs:
         env:
           FIREBASE_CREDS_PATH: ${{ github.workspace }}/secrets/authenticator_play_firebase-creds.json
         run: |
-          bundle exec fastlane distributeReleaseBundleToFirebaseAuthenticator \
+          bundle exec fastlane distributeAuthenticatorReleaseBundleToFirebase \
           serviceCredentialsFile:${{ env.FIREBASE_CREDS_PATH }}
 
       # Only publish bundles to Play Store when `publish-to-play-store` is true while building
@@ -278,5 +279,5 @@ jobs:
         env:
           PLAY_STORE_CREDS_FILE: ${{ github.workspace }}/secrets/authenticator_play_store-creds.json
         run: |
-          bundle exec fastlane publishReleaseToGooglePlayStoreAuthenticator \
+          bundle exec fastlane publishAuthenticatorReleaseToGooglePlayStore \
           serviceCredentialsFile:${{ env.PLAY_STORE_CREDS_FILE }} \

--- a/.github/workflows/test_authenticator.yml
+++ b/.github/workflows/test_authenticator.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and test
         run: |
-          bundle exec fastlane check-bwa
+          bundle exec fastlane checkAuthenticator
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,0 @@
-json_key_file("secrets/authenticator_play_store-creds.json")
-package_name("com.bitwarden.authenticator")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,14 +19,12 @@ platform :android do
 
   desc "Runs tests"
   lane :checkAuthenticator do
-    gradle(
-        tasks: ["testDebug", "lintDebug", "detekt","koverXmlReportDebug"]
-    )
+    gradle(tasks: ["authenticator:testDebug", "authenticator:lintDebug", "authenticator:detekt","authenticator:koverXmlReportDebug"])
   end
 
   desc "Apply build version information to Authenticator"
   fastlane_require "time"
-  lane :setBuildVersionInfoAuthenticator do |options|
+  lane :setAuthenticatorBuildVersionInfo do |options|
 
     # Read-in app build config file.
     buildConfigPath = "../authenticator/build.gradle.kts"
@@ -75,18 +73,18 @@ platform :android do
   end
 
   desc "Assemble Authenticator debug variants"
-  lane :buildDebugAuthenticator do
+  lane :buildAuthenticatorDebug do
     gradle(
-      task: "assemble",
+      task: "authenticator:assemble",
       build_type: "Debug",
       print_command: false,
     )
   end
 
   desc "Assemble and sign Authenticator release APK"
-  lane :buildReleaseAuthenticator do |options|
+  lane :buildAuthenticatorRelease do |options|
     gradle(
-      task: "assemble",
+      task: "authenticator:assemble",
       build_type: "Release",
       properties: {
         "android.injected.signing.store.file" => options[:storeFile],
@@ -99,9 +97,9 @@ platform :android do
   end
 
   desc "Bundle and sign Authenticator release AAB"
-  lane :bundleReleaseAuthenticator do |options|
+  lane :bundleAuthenticatorRelease do |options|
     gradle(
-        task: "bundle",
+        task: "authenticator:bundle",
         build_type: "Release",
         properties: {
           "android.injected.signing.store.file" => options[:storeFile],
@@ -114,13 +112,11 @@ platform :android do
   end
 
   desc "Publish Authenticator release AAB to Firebase"
-  lane :distributeReleaseBundleToFirebaseAuthenticator do |options|
+  lane :distributeAuthenticatorReleaseBundleToFirebase do |options|
     release_notes = changelog_from_git_commits(
       commits_count: 1,
       pretty: "- %s"
     )
-
-    puts "Release notes #{release_notes}"
 
     firebase_app_distribution(
       app: "1:867301491091:android:50b626dba42a361651e866",
@@ -128,13 +124,13 @@ platform :android do
       android_artifact_path: "authenticator/build/outputs/bundle/release/com.bitwarden.authenticator-release.aab",
       service_credentials_file: options[:serviceCredentialsFile],
       groups: "internal-prod-group, livefront",
-      release_notes: release_notes,
     )
   end
 
   desc "Publish Authenticator release to Google Play Store"
-  lane :publishReleaseToGooglePlayStoreAuthenticator do |options|
+  lane :publishAuthenticatorReleaseToGooglePlayStore do |options|
     upload_to_play_store(
+      package_name: "com.bitwarden.authenticator",
       json_key: options[:serviceCredentialsFile],
       track: "internal",
       aab: "authenticator/build/outputs/bundle/release/com.bitwarden.authenticator-release.aab",


### PR DESCRIPTION
## 🎟️ Tracking

--

## 📔 Objective

Renamed the following lanes in the Fastfile to be more specific to the Authenticator module:
- `check` to `checkAuthenticator`
- `setBuildVersionInfo` to `setAuthenticatorBuildVersionInfo`
- `buildDebug` to `buildAuthenticatorDebug`
- `buildRelease` to `buildAuthenticatorRelease`
- `bundleRelease` to `bundleAuthenticatorRelease`
- `distributeReleaseBundleToFirebase` to `distributeAuthenticatorReleaseBundleToFirebase`
- `publishReleaseToGooglePlayStore` to `publishAuthenticatorReleaseToGooglePlayStore`

Updated the GitHub workflows to use the new lane names.

Removed unused `json_key_file` and `package_name` from Appfile.

Added `json_key` parameter to `validate_play_store_json_key` lane in `build_authenticator.yml` workflow.

Added `package_name` parameter to `publishAuthenticatorReleaseToGooglePlayStore` lane in `build_authenticator.yml` workflow.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
