### PR TITLE
PM-17566 - Authenticator Sync: In Dark theme, the Action card in the Authenticator is too dark

### DIFF
--- a/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/card/BitwardenActionCard.kt
+++ b/app/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/card/BitwardenActionCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 
 /**
  * A reusable card for displaying actions to the user.
@@ -40,56 +41,55 @@ fun BitwardenActionCard(
     modifier: Modifier = Modifier,
     trailingContent: (@Composable BoxScope.() -> Unit)? = null,
 ) {
-    Card(
-        onClick = onCardClicked,
-        shape = RoundedCornerShape(size = 16.dp),
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
-        ),
-        elevation = CardDefaults.elevatedCardElevation(),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(),
+    AuthenticatorTheme {
+        Card(
+            onClick = onCardClicked,
+            shape = RoundedCornerShape(size = 16.dp),
+            modifier = modifier,
+            elevation = CardDefaults.elevatedCardElevation(),
         ) {
-            Icon(
-                painter = actionIcon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
+            Row(
                 modifier = Modifier
-                    .padding(
-                        start = 16.dp,
-                        top = 16.dp,
-                    )
-                    .size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(16.dp))
-            Column(
-                modifier = Modifier
-                    .weight(weight = 1f)
-                    .padding(top = 16.dp, bottom = 16.dp),
+                    .fillMaxWidth(),
             ) {
-                Text(
-                    text = titleText,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
+                Icon(
+                    painter = actionIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(
+                            start = 16.dp,
+                            top = 16.dp,
+                        )
+                        .size(24.dp),
                 )
-                Text(
-                    text = actionText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = callToActionText,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Box {
-                trailingContent?.invoke(this)
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(
+                    modifier = Modifier
+                        .weight(weight = 1f)
+                        .padding(top = 16.dp, bottom = 16.dp),
+                ) {
+                    Text(
+                        text = titleText,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = actionText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = callToActionText,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                Box {
+                    trailingContent?.invoke(this)
+                }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17566](https://bitwarden.atlassian.net/browse/PM-17566)

## 📔 Objective

- The `BitwardenActionCard` wasn't using the `AuthenticatorTheme` so it was showing up as too dark.  Updated the logic to use the theme which fixed the issue.

## 📸 Screenshots
### Before
![Screenshot_1739286084](https://github.com/user-attachments/assets/7b192848-1ba1-449d-86d2-7c47c10a3583)

### After
![Screenshot_1739285434](https://github.com/user-attachments/assets/3517c2b7-8daa-4e59-83e2-0efc3f927583)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17566]: https://bitwarden.atlassian.net/browse/PM-17566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ