### PR TITLE
[PM-16534] Update gradle invocations to specify authenticator module

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,16 +75,16 @@ platform :android do
   desc "Assemble debug variants"
   lane :buildAuthenticatorDebug do
     gradle(
-      task: "assemble",
+      task: "authenticator:assemble",
       build_type: "Debug",
       print_command: false,
     )
   end
 
   desc "Assemble and sign release APK"
-  lane :buildAuthenticatordRelease do |options|
+  lane :buildAuthenticatorRelease do |options|
     gradle(
-      task: "assemble",
+      task: "authenticator:assemble",
       build_type: "Release",
       properties: {
         "android.injected.signing.store.file" => options[:storeFile],
@@ -99,7 +99,7 @@ platform :android do
   desc "Bundle and sign release AAB"
   lane :bundleAuthenticatorRelease do |options|
     gradle(
-        task: "bundle",
+        task: "authenticator:bundle",
         build_type: "Release",
         properties: {
           "android.injected.signing.store.file" => options[:storeFile],


### PR DESCRIPTION
## 🎟️ Tracking

PM-16534

## 📔 Objective

Once migrated, the authenticator builds must specify the module in the task name to prevent tasks in unrelated modules from executing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
