### PR TITLE
Update Bitwarden SDK and use `sdk-android-temp`

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/sdk/AuthenticatorSdkSource.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/sdk/AuthenticatorSdkSource.kt
@@ -1,7 +1,7 @@
 package com.bitwarden.authenticator.data.authenticator.datasource.sdk
 
 import com.bitwarden.core.DateTime
-import com.bitwarden.core.TotpResponse
+import com.bitwarden.vault.TotpResponse
 
 /**
  * Source of authenticator information from the Bitwarden SDK.

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/sdk/AuthenticatorSdkSourceImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/sdk/AuthenticatorSdkSourceImpl.kt
@@ -2,9 +2,9 @@ package com.bitwarden.authenticator.data.authenticator.datasource.sdk
 
 import com.bitwarden.authenticator.data.platform.manager.SdkClientManager
 import com.bitwarden.core.DateTime
-import com.bitwarden.core.TotpResponse
 import com.bitwarden.generators.PasswordGeneratorRequest
 import com.bitwarden.sdk.Client
+import com.bitwarden.vault.TotpResponse
 import javax.inject.Inject
 
 /**

--- a/authenticator/src/main/res/values/styles.xml
+++ b/authenticator/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="BaseTheme" parent="Theme.Design.Light.NoActionBar">
+    <style name="BaseTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:textCursorDrawable">@null</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ androidxTestRules = "1.6.1"
 androidXAppCompat = "1.7.0"
 androdixAutofill = "1.1.0"
 androidxWork = "2.10.0"
-bitwardenSdk = "0.4.0-20240314.115913-173"
+bitwardenSdk = "1.0.0-20250213.181812-113"
 crashlytics = "3.0.2"
 detekt = "1.23.7"
 espresso = "3.6.1"
@@ -90,7 +90,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTestRules" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
-bitwarden-sdk = { module = "com.bitwarden:sdk-android", version.ref = "bitwardenSdk" }
+bitwarden-sdk = { module = "com.bitwarden:sdk-android-temp", version.ref = "bitwardenSdk" }
 bumptech-glide = { module = "com.github.bumptech.glide:compose", version.ref = "glide" }
 detekt-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-detekt-rules = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

- Update Bitwarden SDK to `1.0.0-20250213.181812-113`.
- Use `sdk-android-temp` module for the Bitwarden SDK.
- Update the `TotpResponse` import to come from the `com.bitwarden.vault` package instead of `com.bitwarden.core`.
- Change `BaseTheme` parent to `Theme.AppCompat.Light.NoActionBar`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
